### PR TITLE
clawcipes: scaffold-team smoke regression check (testing lane docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Start here:
 - Agents + skills: `docs/AGENTS_AND_SKILLS.md`
 - Tutorial (create a recipe): `docs/TUTORIAL_CREATE_RECIPE.md`
 
+## Development
+### Scaffold smoke test (regression)
+A lightweight smoke check validates scaffold-team output contains the required testing workflow docs (ticket 0004).
+
+Run:
+- `npm run scaffold:smoke`
+
+Notes:
+- Creates a temporary `workspace-smoke-<timestamp>-team` under `~/.openclaw/` and then deletes it.
+- Exits non-zero on mismatch.
+
 Reference:
 - Commands: `docs/COMMANDS.md`
 - Recipe format: `docs/RECIPE_FORMAT.md`

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "scripts": {
     "test": "npm run smoke",
-    "smoke": "node scripts/scaffold-smoke.mjs"
+    "smoke": "node scripts/scaffold-smoke.mjs",
+    "scaffold:smoke": "node scripts/scaffold-smoke.mjs"
   },
   "keywords": [
     "openclaw",

--- a/scripts/scaffold-smoke.mjs
+++ b/scripts/scaffold-smoke.mjs
@@ -1,76 +1,105 @@
-import { execFileSync } from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
+#!/usr/bin/env node
 
-function sh(cmd, args, opts={}){
-  return execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', ...opts });
-}
+import fs from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 
-function assert(cond, msg){
-  if(!cond){
-    console.error(`ASSERT FAIL: ${msg}`);
-    process.exit(1);
+const die = (msg) => {
+  console.error(`\n[scaffold-smoke] ERROR: ${msg}`);
+  process.exitCode = 1;
+};
+
+const run = (cmd, args, opts = {}) => {
+  const res = spawnSync(cmd, args, { encoding: "utf8", ...opts });
+  if (res.status !== 0) {
+    const stderr = String(res.stderr ?? "").trim();
+    const stdout = String(res.stdout ?? "").trim();
+    throw new Error(
+      `Command failed (exit=${res.status}): ${cmd} ${args.join(" ")}\n` +
+        (stdout ? `stdout:\n${stdout}\n` : "") +
+        (stderr ? `stderr:\n${stderr}\n` : "")
+    );
+  }
+  return { stdout: String(res.stdout ?? ""), stderr: String(res.stderr ?? "") };
+};
+
+const assert = (cond, msg) => {
+  if (!cond) throw new Error(msg);
+};
+
+const assertMatch = (text, re, msg) => {
+  if (!re.test(text)) {
+    const preview = text.slice(0, 600);
+    throw new Error(`${msg}\nRegex: ${re}\nPreview:\n${preview}`);
+  }
+};
+
+const fileExists = async (p) => {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+async function main() {
+  const ts = Date.now();
+  const teamId = `smoke-${ts}-team`;
+
+  // Resolve team workspace dir: sibling of agents.defaults.workspace -> workspace-<teamId>
+  const wsOut = run("openclaw", ["config", "get", "agents.defaults.workspace"]).stdout.trim();
+  assert(wsOut, "agents.defaults.workspace not set");
+  const teamDir = path.resolve(wsOut, "..", `workspace-${teamId}`);
+
+  console.log(`[scaffold-smoke] teamId=${teamId}`);
+  console.log(`[scaffold-smoke] teamDir=${teamDir}`);
+
+  let scaffoldOk = false;
+  try {
+    // Scaffold using the built-in development-team recipe.
+    run("openclaw", ["recipes", "scaffold-team", "development-team", "-t", teamId, "--overwrite"]);
+    scaffoldOk = true;
+
+    const teamMdPath = path.join(teamDir, "TEAM.md");
+    const ticketsMdPath = path.join(teamDir, "TICKETS.md");
+    const testingDir = path.join(teamDir, "work", "testing");
+
+    assert(await fileExists(teamMdPath), `Missing TEAM.md at ${teamMdPath}`);
+    assert(await fileExists(ticketsMdPath), `Missing TICKETS.md at ${ticketsMdPath}`);
+    assert(await fileExists(testingDir), `Missing work/testing/ dir at ${testingDir}`);
+
+    const [teamMd, ticketsMd] = await Promise.all([
+      fs.readFile(teamMdPath, "utf8"),
+      fs.readFile(ticketsMdPath, "utf8"),
+    ]);
+
+    // Required content assertions (keep robust)
+    const reTestingPath = /work\/testing\//;
+    const reStagesArrow = /backlog\s*→\s*in-progress\s*→\s*testing\s*→\s*done/i;
+    const reHandoff = /(assign\s+.*test|Owner:\s*test|tester\s+role)/i;
+
+    assertMatch(teamMd, reTestingPath, "TEAM.md must mention work/testing/");
+    assertMatch(teamMd, reStagesArrow, "TEAM.md must mention stages backlog → in-progress → testing → done");
+
+    assertMatch(ticketsMd, reTestingPath, "TICKETS.md must mention work/testing/");
+    assertMatch(ticketsMd, reStagesArrow, "TICKETS.md must mention stages backlog → in-progress → testing → done");
+    assertMatch(ticketsMd, reHandoff, "TICKETS.md must mention QA handoff / assign to test");
+
+    console.log("[scaffold-smoke] OK");
+  } finally {
+    // Best-effort cleanup to avoid littering ~/.openclaw/workspace-*
+    if (scaffoldOk) {
+      try {
+        await fs.rm(teamDir, { recursive: true, force: true });
+        console.log(`[scaffold-smoke] cleaned up ${teamDir}`);
+      } catch (e) {
+        console.error(`[scaffold-smoke] cleanup failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
   }
 }
 
-const recipeId = process.env.RECIPE_ID || 'development-team';
-const teamId = process.env.TEAM_ID || `smoke-${Date.now()}-team`;
-
-// workspace dir naming convention
-const workspaceDir = path.join(os.homedir(), `.openclaw/workspace-${teamId}`);
-
-console.log(`Scaffolding team recipe=${recipeId} teamId=${teamId}`);
-console.log(`Workspace: ${workspaceDir}`);
-
-// Clean any previous leftovers
-try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch {}
-
-// Run scaffold
-const out = sh('openclaw', ['recipes','scaffold-team', recipeId, '-t', teamId, '--overwrite']);
-// Print a tiny bit for debugging
-console.log(out.trim().slice(0, 400));
-
-// Assertions: dirs
-const testingDir = path.join(workspaceDir, 'work', 'testing');
-assert(fs.existsSync(testingDir), `Expected directory to exist: ${testingDir}`);
-
-// Assertions: files contain key strings
-function read(p){
-  return fs.readFileSync(p, 'utf8');
-}
-
-// TEAM.md location: team root
-const teamMd = path.join(workspaceDir, 'TEAM.md');
-const ticketsMd = path.join(workspaceDir, 'TICKETS.md');
-assert(fs.existsSync(teamMd), 'TEAM.md should exist');
-assert(fs.existsSync(ticketsMd), 'TICKETS.md should exist');
-
-const teamTxt = read(teamMd);
-const ticketsTxt = read(ticketsMd);
-
-const mustContain = [
-  'work/testing',
-  'backlog',
-  'in-progress',
-  'testing',
-  'done',
-];
-for(const s of mustContain){
-  assert(teamTxt.includes(s) || ticketsTxt.includes(s), `Expected TEAM.md or TICKETS.md to mention: ${s}`);
-}
-
-// Stronger: look for the lane flow phrase (allow simple variants)
-const flowOk = /backlog\s*→\s*in-?progress\s*→\s*testing\s*→\s*done/i.test(teamTxt + '\n' + ticketsTxt);
-assert(flowOk, 'Expected explicit stage flow: backlog → in-progress → testing → done');
-
-const handoffOk = /(assign(ed)?\s+to\s+test|owner:\s*test|move.*work\/testing)/i.test(teamTxt + '\n' + ticketsTxt);
-assert(handoffOk, 'Expected QA handoff guidance (assign to test / move to work/testing)');
-
-console.log('OK: scaffold smoke assertions passed');
-
-// Cleanup
-if(process.env.KEEP_WORKSPACE !== '1'){
-  fs.rmSync(workspaceDir, { recursive: true, force: true });
-  console.log('Cleaned up workspace');
-}
+main().catch((e) => {
+  die(e instanceof Error ? e.message : String(e));
+});


### PR DESCRIPTION
Adds a lightweight scaffold-team output regression smoke test (no full test harness).

## What
- New script: `scripts/scaffold-smoke.mjs`
- New npm script: `npm run scaffold:smoke` (alias: `npm run smoke` / `npm test` already call smoke)

## Behavior
- Creates a unique throwaway team id: `smoke-<timestamp>-team`
- Runs: `openclaw recipes scaffold-team development-team -t <teamId> --overwrite`
- Asserts:
  - `TEAM.md` exists
  - `TICKETS.md` exists
  - `work/testing/` exists
  - Docs mention:
    - `work/testing/`
    - `backlog → in-progress → testing → done`
    - QA handoff/assign-to-test language
- Cleans up the created `workspace-<teamId>` directory (best-effort, even on failure)

## Note
This smoke test exercises the *installed* `openclaw recipes` plugin. If your local OpenClaw is still pointing at an older recipes extension that doesn’t create `work/testing/` yet, the smoke test will fail (which is correct regression detection).
