### PR TITLE
docs: add cleanup instructions to QA/test role templates

### DIFF
--- a/recipes/default/development-team.md
+++ b/recipes/default/development-team.md
@@ -317,6 +317,32 @@ templates:
     4) If it fails:
        - Move the ticket back to `work/in-progress/` and assign to the right owner.
 
+    ## Cleanup after testing
+
+    If your test involved creating temporary resources (e.g., scaffolding test teams, creating test workspaces), **clean them up** after verification:
+
+    1) Remove test workspaces:
+       ```bash
+       rm -rf ~/.openclaw/workspace-<test-team-id>
+       ```
+
+    2) Remove test agents from config (agents whose id starts with the test team id):
+       - Edit `~/.openclaw/openclaw.json` and remove entries from `agents.list[]`
+       - Or wait for `openclaw recipes remove-team` (once available)
+
+    3) Remove any cron jobs created for the test team:
+       ```bash
+       openclaw cron list --all --json | grep "<test-team-id>"
+       openclaw cron remove <jobId>
+       ```
+
+    4) Restart the gateway if you modified config:
+       ```bash
+       openclaw gateway restart
+       ```
+
+    **Naming convention:** When scaffolding test teams, use a prefix like `qa-<ticketNum>-` (e.g., `qa-0017-social-team`) so cleanup is easier.
+
   test.tools: |
     # TOOLS.md
 

--- a/recipes/default/product-team.md
+++ b/recipes/default/product-team.md
@@ -170,6 +170,32 @@ templates:
     Output conventions:
     - Test plans (optional) go in work/test-plans/
 
+    ## Cleanup after testing
+
+    If your test involved creating temporary resources (e.g., scaffolding test teams, creating test workspaces), **clean them up** after verification:
+
+    1) Remove test workspaces:
+       ```bash
+       rm -rf ~/.openclaw/workspace-<test-team-id>
+       ```
+
+    2) Remove test agents from config (agents whose id starts with the test team id):
+       - Edit `~/.openclaw/openclaw.json` and remove entries from `agents.list[]`
+       - Or wait for `openclaw recipes remove-team` (once available)
+
+    3) Remove any cron jobs created for the test team:
+       ```bash
+       openclaw cron list --all --json | grep "<test-team-id>"
+       openclaw cron remove <jobId>
+       ```
+
+    4) Restart the gateway if you modified config:
+       ```bash
+       openclaw gateway restart
+       ```
+
+    **Naming convention:** When scaffolding test teams, use a prefix like `qa-<ticketNum>-` (e.g., `qa-0017-social-team`) so cleanup is easier.
+
   lead.tools: |
     # TOOLS.md
 


### PR DESCRIPTION
Adds cleanup instructions to the `test.agents` template in `development-team` and `product-team` recipes.

Tells QA to clean up after testing scaffold-related features:
- Remove test workspaces (`trash ~/.openclaw/workspace-<test-team-id>`)
- Remove test agents from config
- Remove cron jobs created for test teams
- Naming convention: `qa-<ticketNum>-<team>` for easy identification

This prevents accumulation of leftover test workspaces like `workspace-qa-0017-*`.