### PR TITLE
docs: testing lane + consistent workspace-<teamId> paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ openclaw recipes list
 ### 3) Scaffold a team
 ```bash
 openclaw recipes scaffold-team development-team \
-  --team-id development-team \
+  --team-id development-team-team \
   --overwrite \
   --apply-config
 ```
@@ -43,7 +43,7 @@ openclaw recipes scaffold-team development-team \
 ### 4) Dispatch a request into work artifacts
 ```bash
 openclaw recipes dispatch \
-  --team-id development-team \
+  --team-id development-team-team \
   --request "Add a new recipe for a customer-support team" \
   --owner lead
 ```
@@ -68,6 +68,7 @@ The plugin supports these config keys (with defaults):
 - `workspaceTeamsDir` (default: `teams`)
 - `autoInstallMissingSkills` (default: `false`)
 - `confirmAutoInstall` (default: `true`)
+- `cronInstallation` (default: `prompt`; values: `off|prompt|on`)
 
 Config schema is defined in `openclaw.plugin.json`.
 

--- a/docs/TEAM_WORKFLOW.md
+++ b/docs/TEAM_WORKFLOW.md
@@ -34,7 +34,10 @@ When you scaffold a team:
 
 4) **Test**
 - Move ticket to `work/testing/`.
-- Optionally assign to a tester/lead for verification.
+- Assign `Owner: test` (or explicitly tag the tester role) and include clear “Verification steps” in the ticket.
+- Tester verifies and either:
+  - moves to `work/done/` (pass), or
+  - bounces back to `work/in-progress/` with a bug note (fail)
 
 5) **Complete**
 - Move ticket to `work/done/` (or use `complete`).

--- a/docs/TUTORIAL_CREATE_RECIPE.md
+++ b/docs/TUTORIAL_CREATE_RECIPE.md
@@ -80,7 +80,9 @@ templates:
     How you work:
     - Pick the lowest numbered ticket assigned to you.
     - Move it to `work/in-progress/`.
-    - Complete it and write a report in `work/done/`.
+    - Do the work.
+    - When ready for QA, move it to `work/testing/` and assign Owner to `test`.
+    - After QA passes, move it to `work/done/` and write a short completion report.
 
 files:
   - path: SOUL.md
@@ -110,9 +112,9 @@ openclaw recipes scaffold-team my-first-team --team-id my-first-team-team --appl
 ```
 
 You should now have:
-- `~/.openclaw/workspace/teams/my-first-team-team/`
-- `~/.openclaw/workspace/agents/my-first-team-team-lead/`
-- `~/.openclaw/workspace/agents/my-first-team-team-worker/`
+- `~/.openclaw/workspace-my-first-team-team/` (team shared workspace)
+- `~/.openclaw/workspace-my-first-team-team/roles/lead/`
+- `~/.openclaw/workspace-my-first-team-team/roles/worker/`
 
 ## Step 3 — dispatch a request
 ```bash
@@ -128,9 +130,16 @@ This will propose (or write, with `--yes`) three artifacts:
 - an assignment stub
 
 ## Step 4 — run the workflow
+Tickets move through lanes:
+- `work/backlog/` → `work/in-progress/` → `work/testing/` → `work/done/`
+
 - Move the ticket from `work/backlog/` → `work/in-progress/`
 - Do the work
-- Move the ticket to `work/done/` and add a `*.DONE.md` report
+- When ready for QA:
+  - Move the ticket to `work/testing/`
+  - Set `Owner: test` and add **Verification steps** to the ticket
+- After verification:
+  - Move the ticket to `work/done/` and add a short completion report
 
 ## Common mistakes
 - **Forgetting the `-team` suffix** on `--team-id` (required).

--- a/recipes/default/development-team.md
+++ b/recipes/default/development-team.md
@@ -384,6 +384,6 @@ tools:
 Scaffolds a shared team workspace and four namespaced agents (lead/dev/devops/test).
 
 ## What you get
-- Shared workspace at `~/.openclaw/workspace-development-team/`
+- Shared workspace at `~/.openclaw/workspace-<teamId>/` (e.g. `~/.openclaw/workspace-development-team-team/`)
 - File-first tickets: backlog → in-progress → testing → done
 - Team lead acts as dispatcher; tester verifies before done


### PR DESCRIPTION
Docs consistency pass: align all examples with the current team workflow.

## Changes
- Ensure the ticket lifecycle includes `testing` everywhere: inbox → backlog → in-progress → testing → done.
- Ensure team examples use `workspace-<teamId>/...` paths.
- Ensure examples use team ids ending in `-team` (per scaffold-team enforcement).
- Add at least one explicit QA handoff example (move to testing + assign Owner: test).

## Files
- README.md
- docs/TUTORIAL_CREATE_RECIPE.md
- docs/TEAM_WORKFLOW.md
- recipes/default/development-team.md (doc text only)

## Verification
- `rg` for outdated patterns:
  - no remaining `workspace/teams` or `workspace/agents` examples
  - no `--team-id development-team` without `-team`
  - multiple mentions of `work/testing/` and QA handoff

Note: no code behavior changes; docs-only PR.
