### PR TITLE
tests: vitest harness + core recipes behavior coverage

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1907,4 +1907,26 @@ const recipesPlugin = {
   },
 };
 
+// Internal helpers used by unit tests. Not part of the public plugin API.
+export const __internal = {
+  ensureMainFirstInAgentsList,
+  upsertBindingInConfig,
+  removeBindingsInConfig,
+  stableStringify,
+
+  patchTicketField(md: string, key: string, value: string) {
+    const lineRe = new RegExp(`^${key}:\\s.*$`, "m");
+    if (md.match(lineRe)) return md.replace(lineRe, `${key}: ${value}`);
+    return md.replace(/^(# .+\n)/, `$1\n${key}: ${value}\n`);
+  },
+
+  patchTicketOwner(md: string, owner: string) {
+    return this.patchTicketField(md, "Owner", owner);
+  },
+
+  patchTicketStatus(md: string, status: string) {
+    return this.patchTicketField(md, "Status", status);
+  },
+};
+
 export default recipesPlugin;

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { __internal } from "../index";
+
+describe("recipes plugin core behaviors", () => {
+  test("agent ordering: main is first and is the only default", () => {
+    const cfgObj: any = {
+      agents: {
+        defaults: { workspace: "~/.openclaw/workspace" },
+        list: [
+          { id: "a", default: true },
+          { id: "main", default: false },
+          { id: "b" },
+        ],
+      },
+    };
+
+    __internal.ensureMainFirstInAgentsList(cfgObj, { config: { agents: { defaults: { workspace: "~/.openclaw/workspace" } } } } as any);
+
+    expect(cfgObj.agents.list[0].id).toBe("main");
+    expect(cfgObj.agents.list[0].default).toBe(true);
+    expect(cfgObj.agents.list.filter((a: any) => a.default).map((a: any) => a.id)).toEqual(["main"]);
+  });
+
+  test("bindings precedence: peer-specific bindings are inserted before generic ones", () => {
+    const cfgObj: any = {
+      bindings: [
+        { agentId: "x", match: { channel: "telegram" } },
+      ],
+    };
+
+    const res = __internal.upsertBindingInConfig(cfgObj, {
+      agentId: "y",
+      match: { channel: "telegram", peer: { kind: "dm", id: "123" } },
+    });
+
+    expect(res.changed).toBe(true);
+    expect(cfgObj.bindings[0].agentId).toBe("y");
+    expect(cfgObj.bindings[0].match.peer.id).toBe("123");
+  });
+
+  test("ticket patching is idempotent (Owner + Status)", () => {
+    const md = `# 0001-example\n\n## Context\n...\n`;
+
+    const once = __internal.patchTicketStatus(__internal.patchTicketOwner(md, "test"), "testing");
+    const twice = __internal.patchTicketStatus(__internal.patchTicketOwner(once, "test"), "testing");
+
+    expect(twice).toBe(once);
+    expect(once).toContain("Owner: test");
+    expect(once).toContain("Status: testing");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,8 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    environment: 'node',
-    include: ['tests/**/*.{test,spec}.ts'],
-    testTimeout: 10_000,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Adds/extends a minimal vitest harness for Clawcipes recipes plugin and includes core regression tests.

## What’s included
- Vitest config: `vitest.config.ts`
- New test file: `tests/core.test.ts`
  - Agent ordering: `main` is first + only default
  - Binding precedence: peer-specific bindings inserted before generic ones
  - Ticket header patching: Owner/Status patch is idempotent

## How to run
- `cd ~/clawcipes`
- `npm install`
- `npm test`

## Notes
- Tests avoid a live gateway.
- Exposes a small `__internal` export from `index.ts` for unit tests (not part of plugin public API).
