### PR TITLE
feat: add remove-team; rebrand to ClawRecipes; package as @jiggai/clawrecipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Clawcipes (OpenClaw Recipes Plugin)
+# ClawRecipes (OpenClaw Recipes Plugin)
 
 <p align="center">
-  <img src="./clawcipes_cook.jpg" alt="Clawcipes logo" width="240" />
+  <img src="./clawrecipes_cook.jpg" alt="ClawRecipes logo" width="240" />
 </p>
 
-Clawcipes is an OpenClaw plugin that provides **CLI-first recipes** for scaffolding specialist agents and teams from Markdown.
+ClawRecipes is an OpenClaw plugin that provides **CLI-first recipes** for scaffolding specialist agents and teams from Markdown.
 
-If you like durable workflows: Clawcipes is built around a **file-first team workspace** (inbox/backlog/in-progress/testing/done) that plays nicely with git.
+If you like durable workflows: ClawRecipes is built around a **file-first team workspace** (inbox/backlog/in-progress/testing/done) that plays nicely with git.
 
 ## Quickstart
 ### 1) Install
@@ -14,15 +14,15 @@ If you like durable workflows: Clawcipes is built around a **file-first team wor
 Once published:
 
 ```bash
-openclaw plugins install @clawcipes/recipes
+openclaw plugins install @jiggai/clawrecipes
 openclaw gateway restart
 openclaw plugins list
 ```
 
 #### Option B: install from GitHub
 ```bash
-git clone https://github.com/rjdjohnston/clawcipes.git ~/clawcipes
-openclaw plugins install --link ~/clawcipes
+git clone https://github.com/JIGGAI/ClawRecipes.git ~/clawrecipes
+openclaw plugins install --link ~/clawrecipes
 openclaw gateway restart
 openclaw plugins list
 ```
@@ -98,9 +98,9 @@ Reference:
 - Recipe format: `docs/RECIPE_FORMAT.md`
 - Bundled recipes: `docs/BUNDLED_RECIPES.md`
 - Team workflow: `docs/TEAM_WORKFLOW.md`
-- Clawcipes Kitchen (UI): `docs/CLAWCIPES_KITCHEN.md`
+- ClawRecipes Kitchen (UI): `docs/CLAWCIPES_KITCHEN.md`
 
-(Also see: GitHub repo https://github.com/rjdjohnston/clawcipes)
+(Also see: GitHub repo https://github.com/JIGGAI/ClawRecipes)
 ## Notes / principles
 - Workspaces:
   - Standalone agents: `~/.openclaw/workspace-<agentId>/`
@@ -112,25 +112,21 @@ Reference:
 - Recipe template rendering is intentionally simple: `{{var}}` replacement only.
 
 ## Removing (uninstalling) a scaffolded team
-Clawcipes does not (yet) include a first-class `remove-team` command.
+ClawRecipes includes a safe uninstall command:
 
-To remove a scaffolded team created with `scaffold-team --apply-config`, do two things:
-
-1) Remove the team workspace (recommended: send to trash):
 ```bash
-trash ~/.openclaw/workspace-<teamId>
-```
-
-2) Remove the agents from OpenClaw config:
-- Edit `~/.openclaw/openclaw.json`
-- Delete the matching entries under `agents.list[]` whose `id` starts with `<teamId>-`
-- Restart:
-```bash
+openclaw recipes remove-team --team-id <teamId> --plan --json
+openclaw recipes remove-team --team-id <teamId> --yes
 openclaw gateway restart
 ```
 
+Notes:
+- The command is confirmation-gated by default (use `--yes` to apply).
+- Cron cleanup is conservative: it removes only cron jobs that are explicitly **stamped** with `recipes.teamId=<teamId>`.
+- If you need a manual fallback, you can still delete `~/.openclaw/workspace-<teamId>` and remove `<teamId>-*` agents from `agents.list[]` in `~/.openclaw/openclaw.json`.
+
 ## Links
-- GitHub: https://github.com/rjdjohnston/clawcipes
+- GitHub: https://github.com/JIGGAI/ClawRecipes
 - Docs:
   - Installation: `docs/INSTALLATION.md`
   - Commands: `docs/COMMANDS.md`
@@ -138,7 +134,7 @@ openclaw gateway restart
   - Team workflow: `docs/TEAM_WORKFLOW.md`
 
 ## What you should be developing (not this plugin)
-Clawcipes is meant to be *installed* and then used to build **agents + teams**.
+ClawRecipes is meant to be *installed* and then used to build **agents + teams**.
 
 Most users should focus on:
 - authoring recipes in their OpenClaw workspace (`<workspace>/recipes/*.md`)

--- a/docs/AGENTS_AND_SKILLS.md
+++ b/docs/AGENTS_AND_SKILLS.md
@@ -1,6 +1,6 @@
-# Agents and skills (OpenClaw + Clawcipes)
+# Agents and skills (OpenClaw + ClawRecipes)
 
-This doc explains the mental model: **what an agent is**, how **skills/tools** work, and how Clawcipes helps you build agents + teams.
+This doc explains the mental model: **what an agent is**, how **skills/tools** work, and how ClawRecipes helps you build agents + teams.
 
 ## What is an agent?
 In OpenClaw, an **agent** is a configured assistant persona with:
@@ -9,7 +9,7 @@ In OpenClaw, an **agent** is a configured assistant persona with:
 - a **tool policy** (what tools it is allowed to use)
 - a **model** configuration (defaults come from OpenClaw)
 
-In Clawcipes, a **standalone** agent recipe scaffolds a dedicated workspace like:
+In ClawRecipes, a **standalone** agent recipe scaffolds a dedicated workspace like:
 
 ```
 ~/.openclaw/workspace-<agentId>/
@@ -38,7 +38,7 @@ In OpenClaw, skills are surfaced as tools the agent can use.
 ## Tool policies (allow/deny)
 Every agent can have a tool policy in OpenClaw config (written via `--apply-config` when scaffolding).
 
-Clawcipes recipes commonly use:
+ClawRecipes recipes commonly use:
 - `allow: ["group:fs", "group:web"]` for safe file + web access
 - `allow: ["group:runtime"]` when the agent needs to run local commands
 - `allow: ["group:automation"]` for automation-oriented tools
@@ -84,7 +84,7 @@ openclaw gateway restart
 > Tip: if you later re-run scaffold with `--apply-config`, the recipe’s tool policy may overwrite your manual edits. If you want a change to stick, encode it in the recipe.
 
 ## Installing skills (workspace-local)
-Clawcipes favors **workspace-local** installs so each OpenClaw workspace is self-contained.
+ClawRecipes favors **workspace-local** installs so each OpenClaw workspace is self-contained.
 
 ### Install a skill slug
 ```bash
@@ -112,7 +112,7 @@ openclaw recipes install <recipe-id>
 That installs the recipe’s declared skills.
 
 ### Removing a skill
-Clawcipes currently does **not** implement a remove command.
+ClawRecipes currently does **not** implement a remove command.
 
 To remove a workspace-local skill:
 - delete the folder: `<workspace>/skills/<skill-slug>`
@@ -121,22 +121,17 @@ To remove a workspace-local skill:
 (We can add `openclaw recipes uninstall <slug>` later if you want it to be first-class.)
 
 ## Removing (uninstalling) a scaffolded team
-Clawcipes does not (yet) include a first-class `remove-team` command.
+ClawRecipes includes a safe uninstall command:
 
-If you scaffolded a team with `scaffold-team --apply-config`, removal has two parts:
-
-1) Remove the team workspace (recommended: send to trash):
 ```bash
-trash ~/.openclaw/workspace-<teamId>
-```
-
-2) Remove the agents from OpenClaw config:
-- Edit `~/.openclaw/openclaw.json`
-- Delete the matching entries under `agents.list[]` whose `id` starts with `<teamId>-`
-- Restart:
-```bash
+openclaw recipes remove-team --team-id <teamId> --plan --json
+openclaw recipes remove-team --team-id <teamId> --yes
 openclaw gateway restart
 ```
+
+Notes:
+- Cron cleanup is conservative: it removes only cron jobs explicitly stamped with `recipes.teamId=<teamId>`.
+- You can still do it manually by deleting `~/.openclaw/workspace-<teamId>` and removing `<teamId>-*` entries from `agents.list[]` in `~/.openclaw/openclaw.json`.
 
 ## Teams: shared workspace + multiple agents
 A **team** recipe scaffolds a **shared workspace root** plus role folders:
@@ -197,7 +192,7 @@ openclaw recipes scaffold-team <recipeId> --team-id <teamId> --overwrite
 ```
 
 ### 2) The agent’s OpenClaw config (tool permissions, identity, model)
-When you scaffold with `--apply-config`, Clawcipes writes the agent entry into OpenClaw config:
+When you scaffold with `--apply-config`, ClawRecipes writes the agent entry into OpenClaw config:
 - `~/.openclaw/openclaw.json` → `agents.list[]`
 
 Re-run scaffold/scaffold-team with `--apply-config` any time you want the recipe’s tool policy (allow/deny) to be re-applied.

--- a/docs/BUNDLED_RECIPES.md
+++ b/docs/BUNDLED_RECIPES.md
@@ -1,6 +1,6 @@
 # Bundled recipes
 
-Clawcipes ships with a few recipes in `recipes/default/`.
+ClawRecipes ships with a few recipes in `recipes/default/`.
 
 You can:
 - list them: `openclaw recipes list`

--- a/docs/CLAWCIPES_KITCHEN.md
+++ b/docs/CLAWCIPES_KITCHEN.md
@@ -1,6 +1,6 @@
-# Clawcipes Kitchen (UI)
+# ClawRecipes Kitchen (UI)
 
-Clawcipes Kitchen is our UI for managing Clawcipes workflows.
+ClawRecipes Kitchen is our UI for managing ClawRecipes workflows.
 
 ## What it’s for
 - Activity feed (high-level semantic events)
@@ -11,11 +11,11 @@ Clawcipes Kitchen is our UI for managing Clawcipes workflows.
 - Approvals inbox + routing (e.g., Telegram)
 
 ## Status
-Clawcipes Kitchen is under active development.
+ClawRecipes Kitchen is under active development.
 
 ## Relationship to the plugin
-- The **Clawcipes plugin** is CLI-first and works without any UI.
-- Clawcipes Kitchen is an optional UI companion for:
+- The **ClawRecipes plugin** is CLI-first and works without any UI.
+- ClawRecipes Kitchen is an optional UI companion for:
   - visibility (activity/search)
   - approvals
   - human review of plans and changes

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -14,22 +14,22 @@ This repo is an **OpenClaw plugin** (not a standalone CLI). OpenClaw loads it an
 Once published, you can install directly via npm:
 
 ```bash
-openclaw plugins install @clawcipes/recipes
+openclaw plugins install @jiggai/clawrecipes
 openclaw gateway restart
 openclaw plugins list
 ```
 
 ### Option B: install from GitHub
 ```bash
-git clone https://github.com/rjdjohnston/clawcipes.git ~/clawcipes
-openclaw plugins install --link ~/clawcipes
+git clone https://github.com/JIGGAI/ClawRecipes.git ~/clawrecipes
+openclaw plugins install --link ~/clawrecipes
 openclaw gateway restart
 openclaw plugins list
 ```
 
 ### Option B: already cloned
 ```bash
-openclaw plugins install --link ~/clawcipes
+openclaw plugins install --link ~/clawrecipes
 openclaw gateway restart
 openclaw plugins list
 ```
@@ -49,7 +49,7 @@ openclaw recipes list
 If you pull a newer version from GitHub, restart the gateway so OpenClaw reloads the plugin:
 
 ```bash
-cd ~/clawcipes
+cd ~/clawrecipes
 git pull
 openclaw gateway restart
 ```

--- a/docs/RECIPE_FORMAT.md
+++ b/docs/RECIPE_FORMAT.md
@@ -83,7 +83,7 @@ agents:
 For team recipes, file templates are namespaced by role:
 - `lead.soul`, `dev.soul`, etc.
 
-If a `files[].template` key does not contain a `.`, Clawcipes prefixes it with `<role>.`.
+If a `files[].template` key does not contain a `.`, ClawRecipes prefixes it with `<role>.`.
 
 ## Cron jobs (optional)
 Recipes can optionally declare cron jobs to be reconciled during `scaffold` / `scaffold-team`.

--- a/docs/TEAM_WORKFLOW.md
+++ b/docs/TEAM_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Team workflow (file-first)
 
-Clawcipes’ differentiator is the **shared team workspace** + a simple, durable, file-first workflow.
+ClawRecipes’ differentiator is the **shared team workspace** + a simple, durable, file-first workflow.
 
 ## Team workspace structure
 When you scaffold a team:

--- a/docs/TUTORIAL_CREATE_RECIPE.md
+++ b/docs/TUTORIAL_CREATE_RECIPE.md
@@ -8,7 +8,7 @@ You’ll learn:
 - how templates/files are written
 - how to scaffold a team and run the file-first workflow
 
-## Step 0 — confirm Clawcipes is installed
+## Step 0 — confirm ClawRecipes is installed
 ```bash
 openclaw plugins list
 openclaw recipes list

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@clawcipes/recipes",
+  "name": "@jiggai/clawrecipes",
   "version": "0.2.7",
-  "description": "Clawcipes recipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
+  "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",
   "type": "commonjs",
   "openclaw": {
@@ -29,7 +29,7 @@
   },
   "keywords": [
     "openclaw",
-    "clawcipes",
+    "clawrecipes",
     "plugin",
     "recipes"
   ],

--- a/src/lib/remove-team.ts
+++ b/src/lib/remove-team.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type CronJob = {
+  id: string;
+  name?: string;
+  enabled?: boolean;
+  schedule?: any;
+  payload?: { kind?: string; message?: string };
+  delivery?: any;
+  agentId?: string;
+};
+
+export type CronStore = {
+  version: number;
+  jobs: CronJob[];
+};
+
+export type RemoveTeamPlan = {
+  teamId: string;
+  workspaceDir: string;
+  openclawConfigPath: string;
+  cronJobsPath: string;
+  agentsToRemove: string[];
+  cronJobsExact: Array<{ id: string; name?: string }>;
+  cronJobsAmbiguous: Array<{ id: string; name?: string; reason: string }>;
+  notes: string[];
+};
+
+export type RemoveTeamResult = {
+  ok: true;
+  plan: RemoveTeamPlan;
+  removed: {
+    workspaceDir: "deleted" | "missing";
+    agentsRemoved: number;
+    cronJobsRemoved: number;
+  };
+};
+
+export function stampTeamId(teamId: string) {
+  return `recipes.teamId=${teamId}`;
+}
+
+export function isProtectedTeamId(teamId: string) {
+  const t = teamId.trim().toLowerCase();
+  return t === "development-team" || t === "main";
+}
+
+export async function fileExists(p: string) {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadCronStore(cronJobsPath: string): Promise<CronStore> {
+  const raw = await fs.readFile(cronJobsPath, "utf8");
+  const data = JSON.parse(raw) as CronStore;
+  if (!data || typeof data !== "object" || !Array.isArray((data as any).jobs)) {
+    throw new Error(`Invalid cron store: ${cronJobsPath}`);
+  }
+  return data;
+}
+
+export async function saveCronStore(cronJobsPath: string, store: CronStore) {
+  await fs.writeFile(cronJobsPath, JSON.stringify(store, null, 2) + "\n", "utf8");
+}
+
+export async function loadOpenClawConfig(openclawConfigPath: string): Promise<any> {
+  const raw = await fs.readFile(openclawConfigPath, "utf8");
+  // NOTE: openclaw.json is JSON5 in some deployments; but we avoid adding dependency here.
+  // The main plugin already depends on json5; callers may parse using that. For remove-team, keep strict JSON.
+  return JSON.parse(raw);
+}
+
+export async function saveOpenClawConfig(openclawConfigPath: string, cfg: any) {
+  await fs.writeFile(openclawConfigPath, JSON.stringify(cfg, null, 2) + "\n", "utf8");
+}
+
+export function findAgentsToRemove(cfgObj: any, teamId: string) {
+  const list = cfgObj?.agents?.list;
+  if (!Array.isArray(list)) return [] as string[];
+  const prefix = `${teamId}-`;
+  return list
+    .map((a: any) => String(a?.id ?? ""))
+    .filter((id: string) => id && id.startsWith(prefix));
+}
+
+export function planCronJobRemovals(jobs: CronJob[], teamId: string) {
+  const stamp = stampTeamId(teamId);
+  const exact: Array<{ id: string; name?: string }> = [];
+  const ambiguous: Array<{ id: string; name?: string; reason: string }> = [];
+
+  for (const j of jobs) {
+    const msg = String(j?.payload?.message ?? "");
+    const name = String(j?.name ?? "");
+
+    // Exact: message contains the stamp.
+    if (msg.includes(stamp)) {
+      exact.push({ id: j.id, name: j.name });
+      continue;
+    }
+
+    // Ambiguous: name mentions teamId (helpful for manual review).
+    if (name.includes(teamId) || msg.includes(teamId)) {
+      ambiguous.push({ id: j.id, name: j.name, reason: "mentions-teamId" });
+    }
+  }
+
+  return { exact, ambiguous };
+}
+
+export async function buildRemoveTeamPlan(opts: {
+  teamId: string;
+  workspaceRoot: string; // e.g. ~/.openclaw/workspace
+  openclawConfigPath: string; // e.g. ~/.openclaw/openclaw.json
+  cronJobsPath: string; // e.g. ~/.openclaw/cron/jobs.json
+  cfgObj: any;
+  cronStore?: CronStore | null;
+}) {
+  const teamId = opts.teamId.trim();
+  const workspaceDir = path.resolve(path.join(opts.workspaceRoot, "..", `workspace-${teamId}`));
+
+  const notes: string[] = [];
+  if (isProtectedTeamId(teamId)) notes.push(`protected-team:${teamId}`);
+
+  const agentsToRemove = findAgentsToRemove(opts.cfgObj, teamId);
+
+  const jobs = (opts.cronStore?.jobs ?? []) as CronJob[];
+  const cron = planCronJobRemovals(jobs, teamId);
+
+  const plan: RemoveTeamPlan = {
+    teamId,
+    workspaceDir,
+    openclawConfigPath: opts.openclawConfigPath,
+    cronJobsPath: opts.cronJobsPath,
+    agentsToRemove,
+    cronJobsExact: cron.exact,
+    cronJobsAmbiguous: cron.ambiguous,
+    notes,
+  };
+
+  return plan;
+}
+
+export async function executeRemoveTeamPlan(opts: {
+  plan: RemoveTeamPlan;
+  includeAmbiguous?: boolean;
+  cfgObj: any;
+  cronStore: CronStore;
+}) {
+  const { plan } = opts;
+  const teamId = plan.teamId;
+
+  if (isProtectedTeamId(teamId)) {
+    throw new Error(`Refusing to remove protected team: ${teamId}`);
+  }
+
+  // 1) Delete workspace dir
+  const workspaceExists = await fileExists(plan.workspaceDir);
+  if (workspaceExists) {
+    await fs.rm(plan.workspaceDir, { recursive: true, force: true });
+  }
+
+  // 2) Remove agents from config
+  const list = opts.cfgObj?.agents?.list;
+  const before = Array.isArray(list) ? list.length : 0;
+  if (Array.isArray(list)) {
+    const remove = new Set(plan.agentsToRemove);
+    opts.cfgObj.agents.list = list.filter((a: any) => !remove.has(String(a?.id ?? "")));
+  }
+  const after = Array.isArray(opts.cfgObj?.agents?.list) ? opts.cfgObj.agents.list.length : 0;
+
+  // 3) Remove cron jobs from store
+  const exactIds = new Set(plan.cronJobsExact.map((j) => j.id));
+  const ambiguousIds = new Set(plan.cronJobsAmbiguous.map((j) => j.id));
+
+  const removeIds = new Set<string>([...exactIds]);
+  if (opts.includeAmbiguous) {
+    for (const id of ambiguousIds) removeIds.add(id);
+  }
+
+  const beforeJobs = opts.cronStore.jobs.length;
+  opts.cronStore.jobs = opts.cronStore.jobs.filter((j) => !removeIds.has(j.id));
+  const afterJobs = opts.cronStore.jobs.length;
+
+  const result: RemoveTeamResult = {
+    ok: true,
+    plan,
+    removed: {
+      workspaceDir: workspaceExists ? "deleted" : "missing",
+      agentsRemoved: Math.max(0, before - after),
+      cronJobsRemoved: Math.max(0, beforeJobs - afterJobs),
+    },
+  };
+
+  return result;
+}

--- a/tests/remove-team.test.ts
+++ b/tests/remove-team.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  buildRemoveTeamPlan,
+  executeRemoveTeamPlan,
+  stampTeamId,
+  type CronStore,
+} from "../src/lib/remove-team";
+
+async function mkTmpDir() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "clawrecipes-remove-team-"));
+}
+
+describe("remove-team", () => {
+  test("plans agent removals + exact stamped cron jobs", async () => {
+    const tmp = await mkTmpDir();
+    const workspaceRoot = path.join(tmp, "workspace");
+    await fs.mkdir(workspaceRoot, { recursive: true });
+
+    const teamId = "qa-social-team";
+
+    const cfgObj: any = {
+      agents: {
+        list: [
+          { id: "main" },
+          { id: `${teamId}-lead` },
+          { id: `${teamId}-dev` },
+          { id: "unrelated-agent" },
+        ],
+      },
+    };
+
+    const cronStore: CronStore = {
+      version: 1,
+      jobs: [
+        {
+          id: "job-1",
+          name: "Team loop",
+          payload: { kind: "agentTurn", message: `hello\n[recipes] ${stampTeamId(teamId)}` },
+        },
+        {
+          id: "job-2",
+          name: `maybe ${teamId} maybe not`,
+          payload: { kind: "agentTurn", message: `hello` },
+        },
+      ],
+    };
+
+    const plan = await buildRemoveTeamPlan({
+      teamId,
+      workspaceRoot,
+      openclawConfigPath: "(test)",
+      cronJobsPath: path.join(tmp, "cron", "jobs.json"),
+      cfgObj,
+      cronStore,
+    });
+
+    expect(plan.agentsToRemove).toEqual([`${teamId}-lead`, `${teamId}-dev`]);
+    expect(plan.cronJobsExact.map((j) => j.id)).toEqual(["job-1"]);
+    expect(plan.cronJobsAmbiguous.map((j) => j.id)).toEqual(["job-2"]);
+  });
+
+  test("execute removes workspace + config agents + exact cron jobs", async () => {
+    const tmp = await mkTmpDir();
+    const workspaceRoot = path.join(tmp, "workspace");
+    await fs.mkdir(workspaceRoot, { recursive: true });
+
+    const teamId = "qa-social-team";
+    const workspaceDir = path.resolve(path.join(workspaceRoot, "..", `workspace-${teamId}`));
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "README.txt"), "hi", "utf8");
+
+    const cfgObj: any = {
+      agents: {
+        list: [{ id: "main" }, { id: `${teamId}-lead` }, { id: "unrelated" }],
+      },
+    };
+
+    const cronStore: CronStore = {
+      version: 1,
+      jobs: [
+        { id: "job-1", payload: { message: `[recipes] ${stampTeamId(teamId)}` } },
+        { id: "job-2", payload: { message: `hello` } },
+      ],
+    };
+
+    const plan = await buildRemoveTeamPlan({
+      teamId,
+      workspaceRoot,
+      openclawConfigPath: "(test)",
+      cronJobsPath: path.join(tmp, "cron", "jobs.json"),
+      cfgObj,
+      cronStore,
+    });
+
+    const result = await executeRemoveTeamPlan({ plan, cfgObj, cronStore });
+
+    expect(result.ok).toBe(true);
+    expect(result.removed.workspaceDir).toBe("deleted");
+    expect(cfgObj.agents.list.map((a: any) => a.id)).toEqual(["main", "unrelated"]);
+    expect(cronStore.jobs.map((j) => j.id)).toEqual(["job-2"]);
+
+    await expect(fs.stat(workspaceDir)).rejects.toBeTruthy();
+  });
+
+  test("refuses protected teams", async () => {
+    const tmp = await mkTmpDir();
+    const workspaceRoot = path.join(tmp, "workspace");
+    await fs.mkdir(workspaceRoot, { recursive: true });
+
+    const cfgObj: any = { agents: { list: [] } };
+    const cronStore: CronStore = { version: 1, jobs: [] };
+
+    const plan = await buildRemoveTeamPlan({
+      teamId: "development-team",
+      workspaceRoot,
+      openclawConfigPath: "(test)",
+      cronJobsPath: path.join(tmp, "cron", "jobs.json"),
+      cfgObj,
+      cronStore,
+    });
+
+    await expect(executeRemoveTeamPlan({ plan, cfgObj, cronStore })).rejects.toThrow(/protected team/i);
+  });
+});


### PR DESCRIPTION
### What
- Adds `openclaw recipes remove-team --team-id <teamId>` safe uninstall (plan/yes/json)
- Conservative cron cleanup (exact stamp match `recipes.teamId=<teamId>`; lists ambiguous)
- Adds unit tests for remove-team
- Rebrands docs: Clawcipes → ClawRecipes; updates canonical repo links
- Prepares npm package rename: `@jiggai/clawrecipes`

### Notes
- Protected teams (at least `development-team` and `main`) are refused.
- After uninstall, gateway restart is required.

### Verification
- `npm test`
