### PR TITLE
chore: publish as @jiggai/recipes (no OpenClaw id-mismatch warning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you like durable workflows: ClawRecipes is built around a **file-first team w
 Once published:
 
 ```bash
-openclaw plugins install @jiggai/clawrecipes
+openclaw plugins install @jiggai/recipes
 openclaw gateway restart
 openclaw plugins list
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -14,7 +14,7 @@ This repo is an **OpenClaw plugin** (not a standalone CLI). OpenClaw loads it an
 Once published, you can install directly via npm:
 
 ```bash
-openclaw plugins install @jiggai/clawrecipes
+openclaw plugins install @jiggai/recipes
 openclaw gateway restart
 openclaw plugins list
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jiggai/clawrecipes",
+  "name": "@jiggai/recipes",
   "version": "0.2.9",
   "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",


### PR DESCRIPTION
Renames npm package from @jiggai/clawrecipes -> @jiggai/recipes while keeping plugin manifest id=recipes.

This prevents OpenClaw's warning: plugin id mismatch (manifest uses "recipes", entry hints "clawrecipes").

Also updates install docs.

Verification:
- npm test