### PR TITLE
chore: bump version to 0.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clawcipes/recipes",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clawcipes/recipes",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/recipes",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",
   "type": "commonjs",


### PR DESCRIPTION
Bumps package.json/package-lock.json to 0.2.11 to match the published @jiggai/recipes release. (Publishing was done without git-tagging due to existing tags.)