### PR TITLE
chore(release): 0.2.16

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "recipes",
   "name": "Recipes",
   "description": "Markdown recipes that scaffold agents and teams (workspace-local).",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clawcipes/recipes",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clawcipes/recipes",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/recipes",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",
   "type": "commonjs",


### PR DESCRIPTION
Release 0.2.16\n\n- Bumps package.json + package-lock.json\n- Bumps openclaw.plugin.json version to 0.2.16 (so OpenClaw displays the right plugin version)\n\nPublished: @jiggai/recipes@0.2.16