### PR TITLE
chore(release): 0.2.17

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "recipes",
   "name": "Recipes",
   "description": "Markdown recipes that scaffold agents and teams (workspace-local).",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clawcipes/recipes",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clawcipes/recipes",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/recipes",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",
   "type": "commonjs",


### PR DESCRIPTION
Release 0.2.17.

Includes: scaffold-team now writes team.json provenance into the team workspace (teamId+recipeId+recipeName+timestamp) so ClawKitchen can lock the correct parent recipe even for CLI scaffolds. Also bumps openclaw.plugin.json version to match package.json.