### PR TITLE
Dispatch: default lead triage on + lead nudge + comments section

### DIFF
--- a/docs/TEAM_WORKFLOW.md
+++ b/docs/TEAM_WORKFLOW.md
@@ -24,24 +24,66 @@ When you scaffold a team:
 1) **Intake**
 - New requests land in `inbox/`.
 
-2) **Plan**
+2) **(Optional) Nudge / automation**
+- A cron job can periodically ping the team lead to triage `inbox/` and keep work moving.
+
+3) **Plan / triage (lead)**
 - Convert the request into a numbered ticket in `work/backlog/`.
+- Fill out: Context, Requirements, Acceptance Criteria, Tasks, Owner, Status, and verification steps.
+- **Every ticket must include a `## Comments` section.** Agents must check/respond to comments on tickets they’re assigned to **or** where they are mentioned via `@<agentname>`.
 - Filename ordering is the priority queue.
 
-3) **Execute**
+4) **Execute (dev/devops)**
 - Move ticket file to `work/in-progress/` (or use `take`).
 - Do work; write artifacts into `shared/` or agent workspaces.
 
-4) **Test**
+5) **Test**
 - Move ticket to `work/testing/`.
 - Assign `Owner: test` (or explicitly tag the tester role) and include clear “Verification steps” in the ticket.
 - Tester verifies and either:
   - moves to `work/done/` (pass), or
   - bounces back to `work/in-progress/` with a bug note (fail)
 
-5) **Complete**
+6) **Complete**
 - Move ticket to `work/done/` (or use `complete`).
 - Add `Completed:` timestamp (automated by `complete` or `move-ticket --completed`).
+
+## Sub-agents + waking up the lead (important)
+Two concepts people often mix up:
+
+1) **Chatting with a role agent directly**
+- If an agent id exists (configured under `agents.list`), you can start a chat with it directly via UI/CLI.
+
+2) **Asking one agent (usually `main`) to wake/spawn/ping another agent**
+- This uses sub-agent/session tooling, and is gated by the requester’s allowlist.
+
+### Why the lead sometimes “never picks it up”
+Even if `openclaw recipes dispatch` created an inbox entry + backlog ticket, the lead won’t act unless:
+- a human opens the lead agent/chat, **or**
+- an automation loop runs (cron triage), **or**
+- `main` is allowed to message/spawn the lead agent.
+
+### Allowlisting other agents (subagents.allowAgents)
+To allow `main` to target team role agents (like `development-team-lead`), add this to your OpenClaw config:
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "main",
+        subagents: {
+          allowAgents: ["development-team-lead"], // or ["*"] for any configured agent
+        },
+      },
+    ],
+  },
+}
+```
+
+Then restart the gateway.
+
+Tip: use the `agents_list` tool to see what’s currently allowed.
 
 ## Dispatcher command
 The lead can convert a natural-language request into artifacts with:

--- a/recipes/default/development-team.md
+++ b/recipes/default/development-team.md
@@ -10,7 +10,7 @@ cronJobs:
     schedule: "*/30 7-23 * * 1-5"
     timezone: "America/New_York"
     message: "Automated lead triage loop: triage inbox/tickets, assign work, and update notes/status.md."
-    enabledByDefault: false
+    enabledByDefault: true
   - id: execution-loop
     name: "Execution loop"
     schedule: "*/30 7-23 * * 1-5"


### PR DESCRIPTION
## What
- Enable development-team lead triage cron by default
- recipes dispatch now includes a ## Comments section in generated tickets
- recipes dispatch enqueues a system event to agent:<teamId>-lead:main as a best-effort nudge
- Update TEAM_WORKFLOW docs to explain subagents/allowAgents and why lead might not pick up

## Why
Users can run recipes dispatch successfully, but nothing progresses if they don’t start a lead chat and cron is disabled. This makes the default experience more reliable.

## Tests
- npm test (vitest)
- npm run test:smoke