### PR TITLE
feat: remove explicit deny exec in bundled recipes

### DIFF
--- a/recipes/default/researcher.md
+++ b/recipes/default/researcher.md
@@ -68,8 +68,8 @@ files:
 tools:
   profile: "coding"
   allow: ["group:fs", "group:web"]
-  deny: ["exec"]
 ---
 # Researcher Recipe
 
 A single research agent with strong source discipline.
+urce discipline.

--- a/recipes/default/social-team.md
+++ b/recipes/default/social-team.md
@@ -772,7 +772,6 @@ files:
 tools:
   profile: "coding"
   allow: ["group:fs", "group:web"]
-  deny: ["exec"]
 ---
 # Social Team Recipe
 
@@ -790,4 +789,6 @@ Scaffolds a shared team workspace and platform-specialist agents. This team exec
   - allow groups: group:fs, group:runtime, group:web
   - deny: exec
 - Safety note: most bundled teams default to denying `exec` unless a role explicitly needs it.
+
+citly needs it.
 

--- a/recipes/default/stock-trader-team.md
+++ b/recipes/default/stock-trader-team.md
@@ -268,6 +268,27 @@ templates:
     - Calendar/cadence checklists → work/playbook/cadence.md
     - Tooling notes → shared-context/tooling/
 
+files:
+  - path: SOUL.md
+    template: soul
+    mode: createOnly
+  - path: AGENTS.md
+    template: agents
+    mode: createOnly
+  - path: TOOLS.md
+    template: tools
+    mode: createOnly
+  - path: STATUS.md
+    template: status
+    mode: createOnly
+  - path: NOTES.md
+    template: notes
+    mode: createOnly
+
+tools:
+  profile: "coding"
+  allow: ["group:fs", "group:web"]
+  deny: []
 ---
 
 # Stock Trader Team Recipe
@@ -287,3 +308,4 @@ Bundled team recipe.
   - deny: exec
 - Safety note: most bundled teams default to denying `exec` unless a role explicitly needs it.
 
+      

--- a/recipes/default/writing-team.md
+++ b/recipes/default/writing-team.md
@@ -293,7 +293,6 @@ files:
 tools:
   profile: "coding"
   allow: ["group:fs", "group:web"]
-  deny: ["exec"]
 ---
 # Writing Team Recipe
 
@@ -311,4 +310,7 @@ A lightweight writing pipeline that pairs briefs/outlines/drafts/edits with a fi
   - allow groups: group:fs, group:runtime, group:web
   - deny: exec
 - Safety note: most bundled teams default to denying `exec` unless a role explicitly needs it.
+
+
+itly needs it.
 


### PR DESCRIPTION
### What
Remove explicit `deny: ["exec"]` entries from selected bundled recipes.

### Why
Per RJ: we will not disable exec by default in recipes (recipes will use `deny: []` unless they intentionally hard-block exec).

### Files changed
- `recipes/default/researcher.md`
- `recipes/default/social-team.md`
- `recipes/default/stock-trader-team.md`
- `recipes/default/writing-team.md`
