### PR TITLE
Revert PR #36: scaffold-team QA_CHECKLIST/skills dir

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2336,7 +2336,6 @@ const recipesPlugin = {
             await ensureDir(rolesDir);
             const notesDir = path.join(teamDir, "notes");
             const workDir = path.join(teamDir, "work");
-            const skillsDir = path.join(teamDir, "skills");
             const backlogDir = path.join(workDir, "backlog");
             const inProgressDir = path.join(workDir, "in-progress");
             const testingDir = path.join(workDir, "testing");
@@ -2369,8 +2368,6 @@ const recipesPlugin = {
               ensureDir(testingDir),
               ensureDir(doneDir),
               ensureDir(assignmentsDir),
-              // Even if no skills are required/installed, create the dir so UIs can render "No skills installed" cleanly.
-              ensureDir(skillsDir),
             ]);
 
             // Seed shared-context starter schema (createOnly unless --overwrite)
@@ -2380,7 +2377,6 @@ const recipesPlugin = {
 
             const planPath = path.join(notesDir, "plan.md");
             const statusPath = path.join(notesDir, "status.md");
-            const qaChecklistPath = path.join(notesDir, "QA_CHECKLIST.md");
             const goalsIndexPath = path.join(notesDir, "GOALS.md");
             const goalsDir = path.join(notesDir, "goals");
             const goalsReadmePath = path.join(goalsDir, "README.md");
@@ -2388,7 +2384,6 @@ const recipesPlugin = {
 
             const planMd = `# Plan — ${teamId}\n\n- (empty)\n`;
             const statusMd = `# Status — ${teamId}\n\n- (empty)\n`;
-            const qaChecklistMd = `# QA checklist — ${teamId}\n\nUse this template when verifying a ticket before moving it from \`work/testing/\` → \`work/done/\`.\n\n## Ticket\n- Ticket: (e.g. 0007)\n- Title:\n- Date:\n- Tester:\n\n## Environment\n- App/version:\n- Branch/commit:\n- Notes:\n\n## Verification\n- [ ] Repro steps followed\n- [ ] Expected behavior confirmed\n- [ ] No obvious regressions\n\n## Evidence\n- Links/screenshots/logs:\n\n## Result\n- PASS / FAIL\n- Follow-ups (if any):\n`;
             const goalsIndexMd = `# Goals — ${teamId}\n\nThis folder is the canonical home for goals.\n\n## How to use\n- Create one markdown file per goal under: notes/goals/\n- Add a link here for discoverability\n\n## Goals\n- (empty)\n`;
             const goalsReadmeMd = `# Goals folder — ${teamId}\n\nCreate one markdown file per goal in this directory.\n\nRecommended file naming:\n- short, kebab-case, no leading numbers (e.g. \`reduce-support-backlog.md\`)\n\nLink goals from:\n- notes/GOALS.md\n`;
             const ticketsMd = `# Tickets — ${teamId}\n\n## Naming\n- Backlog tickets live in work/backlog/\n- In-progress tickets live in work/in-progress/\n- Testing tickets live in work/testing/\n- Done tickets live in work/done/\n- Filename ordering is the queue: 0001-..., 0002-...\n\n## Stages\n- backlog → in-progress → testing → done\n\n## QA handoff\n- When work is ready for QA: move the ticket to \`work/testing/\` and assign to test.\n\n## Required fields\nEach ticket should include:\n- Title\n- Context\n- Requirements\n- Acceptance criteria\n- Owner (dev/devops/lead/test)\n- Status (queued/in-progress/testing/done)\n\n## Example\n\n\`\`\`md\n# 0001-example-ticket\n\nOwner: dev\nStatus: queued\n\n## Context\n...\n\n## Requirements\n- ...\n\n## Acceptance criteria\n- ...\n\`\`\`\n`;
@@ -2396,7 +2391,6 @@ const recipesPlugin = {
             await ensureDir(goalsDir);
             await writeFileSafely(planPath, planMd, overwrite ? "overwrite" : "createOnly");
             await writeFileSafely(statusPath, statusMd, overwrite ? "overwrite" : "createOnly");
-            await writeFileSafely(qaChecklistPath, qaChecklistMd, overwrite ? "overwrite" : "createOnly");
             await writeFileSafely(goalsIndexPath, goalsIndexMd, overwrite ? "overwrite" : "createOnly");
             await writeFileSafely(goalsReadmePath, goalsReadmeMd, overwrite ? "overwrite" : "createOnly");
             await writeFileSafely(ticketsPath, ticketsMd, overwrite ? "overwrite" : "createOnly");


### PR DESCRIPTION
RJ requested rollback of PR #36.

This reverts merge commit c9030ff (PR #36) which added:
- seeding notes/QA_CHECKLIST.md
- creating an empty skills/ directory

We can reintroduce later behind a more deliberate UX decision (and/or ensure it doesn't affect existing scaffolds unexpectedly).