### PR TITLE
Deep-merge agent tools on config upsert (preserve user customizations)

### DIFF
--- a/src/lib/agent-config.ts
+++ b/src/lib/agent-config.ts
@@ -16,6 +16,18 @@ export function upsertAgentInConfig(cfgObj: AgentsConfigMutable, snippet: AgentC
   const list = cfgObj.agents.list;
   const idx = list.findIndex((a) => a?.id === snippet.id);
   const prev = idx >= 0 ? list[idx] : {};
+  const prevTools = (prev as any)?.tools as undefined | { profile?: string; allow?: string[]; deny?: string[] };
+  const nextTools =
+    snippet.tools === undefined
+      ? prevTools
+      : {
+          ...(prevTools ?? {}),
+          ...(snippet.tools ?? {}),
+          ...(Object.prototype.hasOwnProperty.call(snippet.tools, "profile") ? { profile: snippet.tools.profile } : {}),
+          ...(Object.prototype.hasOwnProperty.call(snippet.tools, "allow") ? { allow: snippet.tools.allow } : {}),
+          ...(Object.prototype.hasOwnProperty.call(snippet.tools, "deny") ? { deny: snippet.tools.deny } : {}),
+        };
+
   const nextAgent = {
     ...prev,
     id: snippet.id,
@@ -24,7 +36,7 @@ export function upsertAgentInConfig(cfgObj: AgentsConfigMutable, snippet: AgentC
       ...(prev?.identity ?? {}),
       ...(snippet.identity ?? {}),
     },
-    tools: snippet.tools ? { ...snippet.tools } : prev?.tools,
+    tools: nextTools,
   };
 
   if (idx >= 0) {

--- a/tests/agent-config.test.ts
+++ b/tests/agent-config.test.ts
@@ -14,4 +14,34 @@ describe("agent-config", () => {
     expect(cfg.agents.list).toHaveLength(1);
     expect(cfg.agents.list[0].workspace).toBe("/new");
   });
+
+  test("deep-merges tools (preserves existing deny when snippet omits deny)", () => {
+    const cfg: any = {
+      agents: {
+        list: [
+          {
+            id: "a1",
+            workspace: "/w1",
+            tools: { profile: "coding", allow: ["group:fs"], deny: ["exec"] },
+          },
+        ],
+      },
+    };
+
+    upsertAgentInConfig(cfg, { id: "a1", workspace: "/w1", tools: { allow: ["group:web"] } });
+
+    expect(cfg.agents.list[0].tools).toEqual({ profile: "coding", allow: ["group:web"], deny: ["exec"] });
+  });
+
+  test("allows explicit clearing when snippet sets deny:[]", () => {
+    const cfg: any = {
+      agents: {
+        list: [{ id: "a1", workspace: "/w1", tools: { deny: ["exec"] } }],
+      },
+    };
+
+    upsertAgentInConfig(cfg, { id: "a1", workspace: "/w1", tools: { deny: [] } });
+
+    expect(cfg.agents.list[0].tools).toEqual({ deny: [] });
+  });
 });


### PR DESCRIPTION
- When scaffolding/apply-config updates agents.list entries, do not wipe user tool policy customizations.
- New semantics: if recipe/snippet provides tools, deep-merge with existing agent.tools; only overwrite profile/allow/deny when explicitly present in the snippet.
- Adds unit tests covering preserve-deny and explicit clearing.

Tests: `npm test`