### PR TITLE
Release v0.2.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/recipes",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/recipes",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/recipes",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",
   "type": "commonjs",


### PR DESCRIPTION
- Bump @jiggai/recipes version to v0.2.24

Notes:
- Includes PR #35 (refactor + tooling) and PR #38 (deep-merge tools preservation) already merged to main

Release steps after merge:
- npm publish @jiggai/recipes@0.2.24
