### PR TITLE
chore: QA checklist only when test role or opt-in

### DIFF
--- a/src/lib/recipe-frontmatter.ts
+++ b/src/lib/recipe-frontmatter.ts
@@ -34,6 +34,13 @@ export type RecipeFrontmatter = {
   kind?: string;
   name?: string;
   cronJobs?: CronJobSpec[];
+
+  /**
+   * If true, scaffold `notes/QA_CHECKLIST.md` even if the team has no `test` role.
+   * If false/omitted, QA checklist is scaffolded only when the team recipe includes a `test` role.
+   */
+  qaChecklist?: boolean;
+
   [k: string]: unknown;
 };
 


### PR DESCRIPTION
Problem: notes/QA_CHECKLIST.md was effectively treated as globally required by convention, even for teams without a QA/test role.

Fix:
- Add optional recipe frontmatter flag: qaChecklist: true
- Scaffold notes/QA_CHECKLIST.md only when:
  - the team recipe includes a test role, and/or
  - qaChecklist: true is set

Why:
- Keeps non-QA teams lighter while preserving the workflow for teams that need it.

How to verify:
- Scaffold a team without a test role → QA_CHECKLIST.md is not created
- Scaffold a team with role: test OR qaChecklist: true → QA_CHECKLIST.md is created

Tests: npm test