### PR TITLE
Fix built-in team recipes: add missing TOOLS/STATUS/NOTES templates

### DIFF
--- a/recipes/default/business-team.md
+++ b/recipes/default/business-team.md
@@ -59,6 +59,21 @@ agents:
       deny: ["exec"]
 
 templates:
+  tools: |
+    # TOOLS.md
+
+    # Agent-local notes (paths, conventions, env quirks).
+
+  status: |
+    # STATUS.md
+
+    - (empty)
+
+  notes: |
+    # NOTES.md
+
+    - (empty)
+
   lead.soul: |
     # SOUL.md
 

--- a/recipes/default/clinic-team.md
+++ b/recipes/default/clinic-team.md
@@ -59,6 +59,21 @@ agents:
       deny: ["exec"]
 
 templates:
+  tools: |
+    # TOOLS.md
+
+    # Agent-local notes (paths, conventions, env quirks).
+
+  status: |
+    # STATUS.md
+
+    - (empty)
+
+  notes: |
+    # NOTES.md
+
+    - (empty)
+
   lead.soul: |
     # SOUL.md
 

--- a/recipes/default/construction-team.md
+++ b/recipes/default/construction-team.md
@@ -59,6 +59,21 @@ agents:
       deny: ["exec"]
 
 templates:
+  tools: |
+    # TOOLS.md
+
+    # Agent-local notes (paths, conventions, env quirks).
+
+  status: |
+    # STATUS.md
+
+    - (empty)
+
+  notes: |
+    # NOTES.md
+
+    - (empty)
+
   lead.soul: |
     # SOUL.md
 

--- a/recipes/default/crypto-trader-team.md
+++ b/recipes/default/crypto-trader-team.md
@@ -59,6 +59,21 @@ agents:
       deny: ["exec"]
 
 templates:
+  tools: |
+    # TOOLS.md
+
+    # Agent-local notes (paths, conventions, env quirks).
+
+  status: |
+    # STATUS.md
+
+    - (empty)
+
+  notes: |
+    # NOTES.md
+
+    - (empty)
+
   lead.soul: |
     # SOUL.md
 

--- a/recipes/default/financial-planner-team.md
+++ b/recipes/default/financial-planner-team.md
@@ -59,6 +59,21 @@ agents:
       deny: ["exec"]
 
 templates:
+  tools: |
+    # TOOLS.md
+
+    # Agent-local notes (paths, conventions, env quirks).
+
+  status: |
+    # STATUS.md
+
+    - (empty)
+
+  notes: |
+    # NOTES.md
+
+    - (empty)
+
   lead.soul: |
     # SOUL.md
 

--- a/recipes/default/law-firm-team.md
+++ b/recipes/default/law-firm-team.md
@@ -59,6 +59,21 @@ agents:
       deny: ["exec"]
 
 templates:
+  tools: |
+    # TOOLS.md
+
+    # Agent-local notes (paths, conventions, env quirks).
+
+  status: |
+    # STATUS.md
+
+    - (empty)
+
+  notes: |
+    # NOTES.md
+
+    - (empty)
+
   lead.soul: |
     # SOUL.md
 

--- a/scripts/add_shared_role_file_templates.py
+++ b/scripts/add_shared_role_file_templates.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Add shared templates.tools/status/notes to built-in team recipes when missing.
+
+These shared templates are used as fallback for per-role file scaffolding when role-specific
+templates like lead.tools are absent.
+
+This avoids having to duplicate boilerplate templates per role.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TEMPLATES_BLOCK = (
+    "  tools: |\n"
+    "    # TOOLS.md\n"
+    "\n"
+    "    # Agent-local notes (paths, conventions, env quirks).\n"
+    "\n"
+    "  status: |\n"
+    "    # STATUS.md\n"
+    "\n"
+    "    - (empty)\n"
+    "\n"
+    "  notes: |\n"
+    "    # NOTES.md\n"
+    "\n"
+    "    - (empty)\n"
+)
+
+
+def has_key(md: str, key: str) -> bool:
+    return re.search(rf"^\s{{2}}{re.escape(key)}:\s*\|\s*$", md, flags=re.M) is not None
+
+
+def patch_file(path: Path) -> bool:
+    md = path.read_text(encoding="utf-8")
+
+    # Only patch team recipes with templates:
+    m = re.search(r"^templates:\s*$", md, flags=re.M)
+    if not m:
+        return False
+
+    changed = False
+    need_any = False
+    for k in ("tools", "status", "notes"):
+        if not has_key(md, k):
+            need_any = True
+
+    if not need_any:
+        return False
+
+    # Insert the shared templates immediately after `templates:` line.
+    insert_at = m.end()
+    md2 = md[:insert_at] + "\n" + TEMPLATES_BLOCK + md[insert_at:]
+
+    path.write_text(md2, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    recipe_dir = root / "recipes" / "default"
+
+    targets = [
+        "business-team.md",
+        "clinic-team.md",
+        "construction-team.md",
+        "crypto-trader-team.md",
+        "financial-planner-team.md",
+        "law-firm-team.md",
+    ]
+
+    any_changed = False
+    for name in targets:
+        p = recipe_dir / name
+        if not p.exists():
+            continue
+        if patch_file(p):
+            print(f"patched: {name}")
+            any_changed = True
+        else:
+            print(f"skip: {name}")
+
+    return 0 if any_changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_team_recipe_templates.py
+++ b/scripts/check_team_recipe_templates.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Scan built-in team recipes for missing per-role templates referenced by files.
+
+Rule:
+- For team recipes, for each agent role R and each file entry with template T,
+  the recipe must define templates["R.<T>"] OR a shared templates["<T>"] (team root).
+
+We only warn; fixes should add minimal missing templates.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+
+def extract_frontmatter(md: str) -> str | None:
+    md = md.lstrip("\ufeff")
+    if not md.startswith("---"):
+        return None
+    # frontmatter ends at a line that is exactly ---
+    m = re.search(r"^---\s*$", md, flags=re.M)
+    if not m:
+        return None
+    start = md.find("---")
+    # find second --- after the first line
+    # locate first newline after initial ---
+    first_nl = md.find("\n")
+    if first_nl == -1:
+        return None
+    m2 = re.search(r"^---\s*$", md[first_nl + 1 :], flags=re.M)
+    if not m2:
+        return None
+    end = first_nl + 1 + m2.start()
+    return md[first_nl + 1 : end]
+
+
+def load_recipe(path: Path) -> Dict[str, Any] | None:
+    text = path.read_text(encoding="utf-8")
+    fm = extract_frontmatter(text)
+    if not fm:
+        return None
+    try:
+        data = yaml.safe_load(fm) or {}
+        if not isinstance(data, dict):
+            return None
+        return data
+    except Exception as e:
+        print(f"{path}: YAML parse error: {e}")
+        return None
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    recipe_dir = root / "recipes" / "default"
+
+    problems: List[Tuple[str, str, str]] = []  # recipe, role, missingKey
+
+    for p in sorted(recipe_dir.glob("*-team.md")):
+        data = load_recipe(p)
+        if not data:
+            continue
+        if str(data.get("kind")) != "team":
+            continue
+
+        files = data.get("files") or []
+        agents = data.get("agents") or []
+        templates = data.get("templates") or {}
+
+        if not isinstance(files, list) or not isinstance(agents, list) or not isinstance(templates, dict):
+            continue
+
+        file_templates: List[str] = []
+        for f in files:
+            if not isinstance(f, dict):
+                continue
+            t = f.get("template")
+            if isinstance(t, str) and t.strip():
+                file_templates.append(t.strip())
+
+        roles: List[str] = []
+        for a in agents:
+            if not isinstance(a, dict):
+                continue
+            r = a.get("role")
+            if isinstance(r, str) and r.strip():
+                roles.append(r.strip())
+
+        # For each role, ensure role-specific templates exist for every file template.
+        for role in roles:
+            for t in file_templates:
+                # allow shared team-root templates like "agents" or "tools".
+                shared_ok = t in templates
+                role_key = f"{role}.{t}"
+                if not shared_ok and role_key not in templates:
+                    problems.append((p.name, role, role_key))
+
+    if not problems:
+        print("OK: no missing per-role templates found")
+        return 0
+
+    # print grouped output
+    by_recipe: Dict[str, List[Tuple[str, str]]] = {}
+    for recipe, role, key in problems:
+        by_recipe.setdefault(recipe, []).append((role, key))
+
+    for recipe, items in by_recipe.items():
+        print(f"\n{recipe}")
+        for role, key in sorted(items):
+            print(f"  - role={role}: missing templates.{key}")
+
+    print(f"\nTotal missing templates: {len(problems)}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Scans built-in team recipes and fixes missing per-role templates (e.g. lead.tools) by adding shared fallback templates under `templates:` for `tools`, `status`, and `notes`.

This prevents scaffold-team from failing with errors like: "Missing template: lead.tools".

Touched recipes:
- business-team.md
- clinic-team.md
- construction-team.md
- crypto-trader-team.md
- financial-planner-team.md
- law-firm-team.md

Tests:
- npm test (vitest) PASS

Includes a small script to detect missing templates: scripts/check_team_recipe_templates.py