### PR TITLE
ci: fix canary republish by using unique version per run

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -40,12 +40,16 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Bump prerelease version (unique per attempt; no git tag)
+      - name: Bump prerelease version (unique per run; no git tag)
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_NUMBER: ${{ github.run_number }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          PREID="canary.${PR_NUMBER}.${RUN_ATTEMPT}"
+          # npm forbids republishing the same version.
+          # github.run_attempt only changes on re-runs of the same workflow run; a new run starts at attempt=1.
+          # So include run_number (monotonic per repo) to guarantee uniqueness across runs.
+          PREID="canary.${PR_NUMBER}.${RUN_NUMBER}.${RUN_ATTEMPT}"
           npm version prerelease --preid "$PREID" --no-git-tag-version
 
       - name: Publish to npm (tag = canary-<pr>)


### PR DESCRIPTION
Fix E403 canary publish retries: npm forbids republishing the same version. Use PR + github.run_number + github.run_attempt in prerelease preid so every run publishes a unique semver, while keeping dist-tag stable as canary-<PR#>.