### PR TITLE
#0106 scaffold-team: create shared-context/memory + starter files

### DIFF
--- a/src/handlers/team.ts
+++ b/src/handlers/team.ts
@@ -29,6 +29,7 @@ async function ensureTeamDirectoryStructure(
     ensureDir(path.join(sharedContextDir, "feedback")),
     ensureDir(path.join(sharedContextDir, "kpis")),
     ensureDir(path.join(sharedContextDir, "calendar")),
+    ensureDir(path.join(sharedContextDir, "memory")),
     ensureDir(path.join(teamDir, "inbox")),
     ensureDir(path.join(teamDir, "outbox")),
     ensureDir(notesDir),
@@ -57,6 +58,22 @@ async function writeTeamBootstrapFiles(opts: {
   await writeFileSafely(
     path.join(sharedContextDir, "priorities.md"),
     `# Priorities — ${teamId}\n\n- (empty)\n\n## Notes\n- Lead curates this file.\n- Non-lead roles should append updates to shared-context/agent-outputs/ instead.\n`,
+    mode
+  );
+
+  // Team memory (file-first, machine-usable). Non-destructive.
+  await ensureDir(path.join(sharedContextDir, "memory"));
+  await writeFileSafely(path.join(sharedContextDir, "memory", "team.jsonl"), "", mode);
+
+  await writeFileSafely(
+    path.join(sharedContextDir, "DECISIONS.md"),
+    `# Decisions — ${teamId}\n\nAppend-only dated bullets.\n\n- (empty)\n`,
+    mode
+  );
+
+  await writeFileSafely(
+    path.join(sharedContextDir, "GLOSSARY.md"),
+    `# Glossary — ${teamId}\n\nTerms, conventions, acronyms.\n\n- (empty)\n`,
     mode
   );
   await writeFileSafely(path.join(notesDir, "plan.md"), `# Plan — ${teamId}\n\n- (empty)\n`, mode);

--- a/tests/scaffold-commands.test.ts
+++ b/tests/scaffold-commands.test.ts
@@ -394,6 +394,11 @@ files: []
         const teamJsonPath = path.join(res.teamDir, "team.json");
         const teamJson = JSON.parse(await fs.readFile(teamJsonPath, "utf8"));
         expect(teamJson.recipeId).toBe("development-team");
+
+        // Team memory + shared-context starter files
+        expect(await fs.readFile(path.join(res.teamDir, "shared-context", "memory", "team.jsonl"), "utf8")).toBeDefined();
+        expect(await fs.readFile(path.join(res.teamDir, "shared-context", "DECISIONS.md"), "utf8")).toContain("# Decisions");
+        expect(await fs.readFile(path.join(res.teamDir, "shared-context", "GLOSSARY.md"), "utf8")).toContain("# Glossary");
       }
     } finally {
       await fs.rm(base, { recursive: true, force: true });


### PR DESCRIPTION
Implements ticket #0106.

What changed
- scaffold-team now ensures  exists
- creates  (create-only)
- creates starter  +  (create-only)
- adds test coverage to assert the files are created

Verification
- 
> @jiggai/recipes@0.3.8 lint
> eslint src/ index.ts
- 
> @jiggai/recipes@0.3.8 test
> vitest run


 RUN  v3.2.4 /home/control/ClawRecipes

 ✓ tests/install-handler.test.ts (12 tests) 42ms
 ✓ tests/ticket-commands.test.ts (18 tests) 71ms
 ✓ tests/index-handlers.test.ts (9 tests) 41ms
 ✓ tests/scaffold-swarm-orchestrator.test.ts (1 test) 262ms
 ✓ tests/recipes-internal.test.ts (5 tests) 264ms
 ✓ tests/cron-handler.test.ts (7 tests) 36ms
 ✓ tests/cleanup-workspaces.test.ts (9 tests) 21ms
 ✓ tests/remove-team.test.ts (3 tests) 7ms
 ✓ tests/ticket-finder.test.ts (12 tests) 19ms
 ✓ tests/recipes-commands.test.ts (10 tests) 503ms
 ✓ tests/workspace.test.ts (6 tests) 8ms
 ✓ tests/take.test.ts (4 tests) 26ms
 ✓ tests/skill-install.test.ts (5 tests) 8ms
 ✓ tests/handoff.test.ts (2 tests) 14ms
 ✓ tests/remove-team-expanded.test.ts (10 tests) 19ms
 ✓ tests/toolsInvoke.test.ts (5 tests) 913ms
   ✓ toolsInvoke > throws on HTTP error response  452ms
   ✓ toolsInvoke > retries on failure (3 attempts)  455ms
 ✓ tests/cron-utils.test.ts (9 tests) 16ms
 ✓ tests/lanes.test.ts (4 tests) 16ms
 ✓ tests/marketplaceFetch.test.ts (4 tests) 7ms
 ✓ tests/shared-context.test.ts (1 test) 5ms
 ✓ tests/fs-utils.test.ts (7 tests) 9ms
 ✓ tests/frontmatter.test.ts (3 tests) 17ms
 ✓ tests/scaffold-commands.test.ts (20 tests) 1039ms
 ✓ tests/prompt.test.ts (8 tests) 5ms
 ✓ tests/recipe-id.test.ts (5 tests) 9ms
 ✓ tests/json-utils.test.ts (3 tests) 8ms
 ✓ tests/template.test.ts (4 tests) 4ms
 ✓ tests/cov-10.test.ts (6 tests) 6ms
 ✓ tests/no-child-process.test.ts (1 test) 7ms
 ✓ tests/cleanup-workspaces-expanded.test.ts (6 tests) 4ms
 ✓ tests/core.test.ts (8 tests) 5ms
 ✓ tests/no-install-warnings.test.ts (1 test) 5ms
 ✓ tests/scaffold-templates.test.ts (2 tests) 4ms
 ✓ tests/agent-config.test.ts (4 tests) 5ms
 ✓ tests/bindings.test.ts (2 tests) 3ms
 ✓ tests/stable-stringify.test.ts (5 tests) 4ms
 ✓ tests/config.test.ts (2 tests) 3ms

 Test Files  37 passed (37)
      Tests  223 passed (223)
   Start at  19:33:51
   Duration  2.10s (transform 837ms, setup 0ms, collect 2.72s, tests 3.43s, environment 8ms, prepare 2.87s)

Notes
- Non-destructive: existing files are not overwritten unless  is used.