### PR TITLE
recipe(development-team): update ticket hygiene + add ticket-flow mapping

### DIFF
--- a/recipes/default/_snippets/shared-context-ticket-flow.json
+++ b/recipes/default/_snippets/shared-context-ticket-flow.json
@@ -1,0 +1,10 @@
+{
+  "laneByOwner": {
+    "dev": "in-progress",
+    "devops": "in-progress",
+    "lead": "backlog",
+    "test": "testing",
+    "qa": "testing"
+  },
+  "defaultLane": "in-progress"
+}


### PR DESCRIPTION
Updates the bundled development-team recipe to match the post-assignment-stubs workflow.

Changes:
- Replace legacy assignment-stub hygiene with a lane/status/owner hygiene script.
  - Enforces only for active lanes (backlog/in-progress/testing); does not block on historical done tickets.
  - Reads best-effort mapping from shared-context/ticket-flow.json when jq is available.
- Update recipe cron messages to say lane/status/owner mismatches (no more stub language).
- Scaffold shared-context/ticket-flow.json (laneByOwner + defaultLane) with default lead→backlog.

Verification:
- npm test ✅