### PR TITLE
ci: skip canary publish for release PRs

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -20,6 +20,9 @@ jobs:
     # Don't publish from forks.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
+      && !contains(join(github.event.pull_request.labels.*.name, ','), 'release')
+
+    # Skip publishing canaries for release PRs (label: release).
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds a guard to the PR canary publish workflow: if the PR has label `release`, skip publishing the canary tag.

This keeps canary builds for normal PRs but avoids publishing canaries when cutting real releases (major/minor/patch).