### PR TITLE
fix: preserve raw string payloads in LLM node output .text

### DIFF
--- a/src/lib/workflows/workflow-node-executor.ts
+++ b/src/lib/workflows/workflow-node-executor.ts
@@ -213,7 +213,8 @@ export async function executeWorkflowNodes(opts: {
         const llmRec = asRecord(llmRes);
         const details = asRecord(llmRec['details']);
         const payload = details['json'] ?? (Object.keys(details).length ? details : llmRes) ?? null;
-        text = JSON.stringify(payload, null, 2);
+        // Store string payloads (e.g. markdown) as-is — see workflow-worker.ts for rationale.
+        text = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
       } catch (e) {
         throw new Error(`LLM execution failed for node ${nodeLabel(node)}: ${e instanceof Error ? e.message : String(e)}`);
       }

--- a/src/lib/workflows/workflow-worker.ts
+++ b/src/lib/workflows/workflow-worker.ts
@@ -889,7 +889,11 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
         const llmRec = asRecord(llmRes);
         const details = asRecord(llmRec['details']);
         const payload = details['json'] ?? (Object.keys(details).length ? details : llmRes) ?? null;
-        text = JSON.stringify(payload, null, 2);
+        // Store string payloads (e.g. markdown) as-is so `{{node.text}}` substitutes
+        // the original content. JSON.stringify(string) would wrap it in quotes and
+        // escape newlines, which breaks downstream fs.write consumers that expect
+        // plain text. Object/array payloads still get pretty-printed.
+        text = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
       } catch (e) {
         const eRec = asRecord(e);
         const errorCategory = classifyError(e);

--- a/tests/workflow-runner-file-first.test.ts
+++ b/tests/workflow-runner-file-first.test.ts
@@ -6,12 +6,18 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 const toolCalls: Array<{ tool: string; args?: any; action?: string }> = [];
 
+// Per-test override for what the mocked llm-task should return. Reset between tests.
+const llmResponseOverride: { value: unknown | undefined } = { value: undefined };
+
 // The workflow runner/worker uses toolsInvoke for message sends (human approval) and llm-task.
 // For unit tests, mock it so we can exercise approval + revision flows without a gateway.
 vi.mock("../src/toolsInvoke", () => {
   return {
     toolsInvoke: async (api: any, req: any) => {
       toolCalls.push({ tool: String(req?.tool ?? ""), args: req?.args, action: req?.action });
+      if (String(req?.tool ?? "") === "llm-task" && llmResponseOverride.value !== undefined) {
+        return llmResponseOverride.value;
+      }
       return { ok: true, mocked: true };
     },
   };
@@ -932,6 +938,167 @@ describe("workflow-runner (file-first + runner/worker)", () => {
       const growthRatio = queueBytesAfter / Math.max(queueBytesBefore, 1);
       expect(growthRatio).toBeLessThan(10); // 10× is generous; real growth is ~5×
     } finally {
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: when an LLM node has no outputFields schema, the model returns a
+  // plain string (e.g. markdown). Prior to the fix, the worker stored
+  // JSON.stringify(string) — which wraps the value in quotes and escapes
+  // newlines — so `{{node.text}}` substitution produced `"# ...\n..."` instead
+  // of raw markdown, breaking downstream fs.write consumers.
+  test("llm node preserves raw string payload in .text (no JSON wrapping)", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-llm-string";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+    const shared = path.join(teamDir, "shared-context");
+    const workflowsDir = path.join(shared, "workflows");
+
+    const markdown = "# Weekly Content Packet\n\n## 1. Executive summary\n- First post\n- Second post\n";
+
+    try {
+      toolCalls.length = 0;
+      llmResponseOverride.value = markdown;
+
+      await fs.mkdir(workflowsDir, { recursive: true });
+      await fs.mkdir(path.join(teamDir, "work", "backlog"), { recursive: true });
+
+      const workflowFile = "llm-string.workflow.json";
+      const workflowPath = path.join(workflowsDir, workflowFile);
+
+      const workflow = {
+        id: "llm-string",
+        name: "Demo: LLM returns raw markdown",
+        nodes: [
+          { id: "start", kind: "start" },
+          {
+            id: "draft_packet",
+            kind: "llm",
+            assignedTo: { agentId: "agent-writer" },
+            action: { promptTemplate: "Return the weekly packet as markdown." },
+          },
+          { id: "end", kind: "end" },
+        ],
+        edges: [
+          { from: "start", to: "draft_packet", on: "success" },
+          { from: "draft_packet", to: "end", on: "success" },
+        ],
+      };
+
+      await fs.writeFile(workflowPath, JSON.stringify(workflow, null, 2), "utf8");
+
+      const api = stubApi();
+      const enq = await enqueueWorkflowRun(api, { teamId, workflowFile });
+      expect(enq.ok).toBe(true);
+
+      const r1 = await runWorkflowRunnerOnce(api, { teamId });
+      expect(r1.ok).toBe(true);
+      const w1 = await runWorkflowWorkerTick(api, { teamId, agentId: "agent-writer", limit: 5, workerId: "w-writer" });
+      expect(w1.ok).toBe(true);
+
+      // Locate the node output file for draft_packet under the run directory.
+      const runsDir = path.join(shared, "workflow-runs");
+      const runDirs = await fs.readdir(runsDir);
+      expect(runDirs.length).toBe(1);
+      const runDir = path.join(runsDir, runDirs[0]!);
+      const nodeOutputsDir = path.join(runDir, "node-outputs");
+      const files = await fs.readdir(nodeOutputsDir);
+      const outputFile = files.find((f) => f.endsWith("-draft_packet.json"));
+      expect(outputFile).toBeDefined();
+
+      const raw = await fs.readFile(path.join(nodeOutputsDir, outputFile!), "utf8");
+      const parsed = JSON.parse(raw) as { text: string };
+
+      // The stored text should equal the raw markdown — NOT a JSON-encoded
+      // string literal. Before the fix this would have been
+      //   "\"# Weekly Content Packet\\n\\n..." (first char = `"`, newlines = `\\n`).
+      expect(parsed.text).toBe(markdown);
+      expect(parsed.text.startsWith("#")).toBe(true);
+      expect(parsed.text.startsWith('"')).toBe(false);
+      expect(parsed.text).not.toContain("\\n");
+    } finally {
+      llmResponseOverride.value = undefined;
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  // Companion: object payloads (structured outputs) still get pretty-printed JSON,
+  // so downstream parsers that rely on JSON.parse(.text) continue to work.
+  test("llm node still JSON-stringifies object payloads", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-llm-object";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+    const shared = path.join(teamDir, "shared-context");
+    const workflowsDir = path.join(shared, "workflows");
+
+    try {
+      toolCalls.length = 0;
+      // Default mock returns { ok: true, mocked: true } — an object payload.
+      llmResponseOverride.value = undefined;
+
+      await fs.mkdir(workflowsDir, { recursive: true });
+      await fs.mkdir(path.join(teamDir, "work", "backlog"), { recursive: true });
+
+      const workflowFile = "llm-object.workflow.json";
+      const workflowPath = path.join(workflowsDir, workflowFile);
+
+      const workflow = {
+        id: "llm-object",
+        name: "Demo: LLM returns structured object",
+        nodes: [
+          { id: "start", kind: "start" },
+          {
+            id: "qc_brand",
+            kind: "llm",
+            assignedTo: { agentId: "agent-qc" },
+            action: { promptTemplate: "Return JSON." },
+          },
+          { id: "end", kind: "end" },
+        ],
+        edges: [
+          { from: "start", to: "qc_brand", on: "success" },
+          { from: "qc_brand", to: "end", on: "success" },
+        ],
+      };
+
+      await fs.writeFile(workflowPath, JSON.stringify(workflow, null, 2), "utf8");
+
+      const api = stubApi();
+      const enq = await enqueueWorkflowRun(api, { teamId, workflowFile });
+      expect(enq.ok).toBe(true);
+
+      const r1 = await runWorkflowRunnerOnce(api, { teamId });
+      expect(r1.ok).toBe(true);
+      const w1 = await runWorkflowWorkerTick(api, { teamId, agentId: "agent-qc", limit: 5, workerId: "w-qc" });
+      expect(w1.ok).toBe(true);
+
+      const runsDir = path.join(shared, "workflow-runs");
+      const runDirs = await fs.readdir(runsDir);
+      const runDir = path.join(runsDir, runDirs[0]!);
+      const nodeOutputsDir = path.join(runDir, "node-outputs");
+      const files = await fs.readdir(nodeOutputsDir);
+      const outputFile = files.find((f) => f.endsWith("-qc_brand.json"));
+      expect(outputFile).toBeDefined();
+
+      const raw = await fs.readFile(path.join(nodeOutputsDir, outputFile!), "utf8");
+      const parsed = JSON.parse(raw) as { text: string };
+
+      // Object payload round-trips as valid JSON in .text.
+      const reparsed = JSON.parse(parsed.text) as { ok: boolean; mocked: boolean };
+      expect(reparsed.ok).toBe(true);
+      expect(reparsed.mocked).toBe(true);
+    } finally {
+      llmResponseOverride.value = undefined;
       process.env.OPENCLAW_WORKSPACE = prevWorkspace;
       await fs.rm(base, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- LLM nodes without an `outputFields` schema return raw strings (markdown). The worker was calling `JSON.stringify(payload, null, 2)` unconditionally, which wrapped strings in quotes and escaped newlines to literal `\n` — so `{{node.text}}` templates produced `"# ...\n..."` instead of real markdown.
- Fix: only stringify non-string payloads. Strings (markdown, plain text) pass through as-is. Objects/arrays/numbers still get pretty-printed JSON.
- Same bug existed in both execution paths: `workflow-worker.ts` (active) and `workflow-node-executor.ts` (older runner). Both fixed.

## Background
Bug has existed since 2026-03-18 (commit [`19cb883c`](https://github.com/JIGGAI/ClawRecipes/commit/19cb883c)). It was silent until a downstream workflow (hmx-marketing-team weekly content generation) switched its templates from `{{node.output}}` to `{{node.text}}` — at which point brand-QC / packet markdown started landing in files as JSON-escaped strings, breaking the dashboard sync (0 posts extracted from a packet that had 28 post blocks).

Prior workaround in the workflow definition was to add `unwrap_packet_markdown` and `unwrap_handoff_markdown` nodes to re-parse the string — those can be removed once this lands.

## Why it's safe
- Downstream consumers in `workflow-node-output-readers.ts` already wrap `JSON.parse(text)` in try/catch, so they handle both wrapped and raw formats. No reader change needed.
- Object payloads (structured outputs with `outputFields`) keep exactly the same behavior they had before.
- Handoff / media paths (`workflow-worker.ts:1348`, `1490`, `1548`) were intentionally left alone — their payloads are always objects.

## Orthogonal to cron v2
The recent ClawKitchen `PAYLOAD_SCHEMA_VERSION = 2` cron migration (`--light-context --tools exec`) is a *different* fix. That addresses the *outer* cron LLM hallucinating the `openclaw recipes workflows worker-tick` CLI path and silently dropping ticks. This PR addresses the *inner* workflow-node LLM's output serialization. Both were needed for the weekly workflow to actually complete.

## Test plan
- [x] `npm test` — 46 files, 279 tests, all passing locally
- [x] Two new regression tests in `tests/workflow-runner-file-first.test.ts`:
  - `llm node preserves raw string payload in .text (no JSON wrapping)` — markdown round-trip, asserts `.text` starts with `#`, not `"`, and contains no literal `\n`
  - `llm node still JSON-stringifies object payloads` — default object payload still pretty-prints and re-parses
- [ ] After merge: remove `unwrap_packet_markdown` + `unwrap_handoff_markdown` nodes from `weekly-content-generation.workflow.json`
- [ ] After merge: revert the parser-level unwrap in `hmx-dashboard/lib/workflow-plans.js` (keep the dead-man check in `sync-weekly-plan-to-posts.mjs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)