### PR TITLE
fix(swarm-orchestrator): validate git refs + bump build.openclawVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       "pluginApiRange": ">=2026.3"
     },
     "build": {
-      "openclawVersion": "2026.3.28"
+      "openclawVersion": "2026.4.20"
     }
   },
   "publishConfig": {

--- a/recipes/default/swarm-orchestrator.md
+++ b/recipes/default/swarm-orchestrator.md
@@ -542,6 +542,10 @@ templates:
       [[ "$1" =~ ^[a-z0-9][a-z0-9-]{0,62}$ ]]
     }
 
+    safe_ref() {
+      [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$ ]]
+    }
+
     cmd="${1:-}"
     shift || true
 
@@ -633,6 +637,14 @@ templates:
         fi
         if [[ -d "$worktree_dir" ]]; then
           echo "Worktree directory already exists: $worktree_dir" >&2
+          exit 2
+        fi
+        if ! safe_ref "$base_ref"; then
+          echo "invalid --base-ref: must match ^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$" >&2
+          exit 2
+        fi
+        if ! safe_ref "$branch"; then
+          echo "invalid --branch: must match ^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$" >&2
           exit 2
         fi
         git worktree add "$worktree_dir" -b "$branch" "$base_ref"


### PR DESCRIPTION
## Summary
- Add `safe_ref()` validator alongside `safe_id()` in the `taskCli` template of `recipes/default/swarm-orchestrator.md` and gate `--base-ref` / `--branch` through it before `git worktree add`.
- Bump `openclaw.build.openclawVersion` in `package.json` from `2026.3.28` → `2026.4.20` (latest on npm).

## Why
clawhub.ai flagged line 562 of `swarm-orchestrator.md` with "User-controlled placeholder is embedded directly into generated source code" because it pattern-matched `${SWARM_BASE_REF}` as a render-time placeholder.

The scaffolder only substitutes `{{key}}` (see `src/lib/template.ts:6`), so `${SWARM_BASE_REF}` is plain bash parameter expansion written verbatim into `.clawdbot/task.sh` — resolved at *runtime* from the user's own `env.sh`, and already used in a properly-quoted position. The scanner warning was a false positive.

The validator is pure defense-in-depth: it makes the code strictly better and typically clears pattern-based scanners because the value now visibly flows through a constrained regex.

## Test plan
- [x] Local `npm test` (279/279 passing, including `scaffold-swarm-orchestrator.test.ts`)
- [ ] CI green
- [ ] Manual check: scaffold the recipe, run `./.clawdbot/task.sh start --task-id x --spec foo --base-ref "main"` — should succeed
- [ ] Manual check: same with `--base-ref "; rm -rf /"` — should exit 2 with regex error

🤖 Generated with [Claude Code](https://claude.com/claude-code)