### PR TITLE
feat(workflows): inline workspace files into LLM prompts via {{file:...}}

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "recipes",
   "name": "Recipes",
   "description": "Markdown recipes that scaffold agents and teams (workspace-local).",
-  "version": "0.4.50",
+  "version": "0.4.58",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/recipes",
-  "version": "0.4.57",
+  "version": "0.4.58",
   "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",
   "type": "commonjs",

--- a/src/lib/workflows/workflow-node-executor.ts
+++ b/src/lib/workflows/workflow-node-executor.ts
@@ -13,7 +13,7 @@ import {
   asRecord, asString,
   ensureDir, fileExists,
   moveRunTicket, appendRunLog, nodeLabel,
-  loadNodeStatesFromRun, sanitizeDraftOnlyText, templateReplace,
+  loadNodeStatesFromRun, sanitizeDraftOnlyText, templateReplace, expandFileIncludes,
 } from './workflow-utils';
 
 export async function resolveApprovalBindingTarget(api: OpenClawPluginApi, bindingId: string): Promise<{ channel: string; target: string; accountId?: string }> {
@@ -180,7 +180,10 @@ export async function executeWorkflowNodes(opts: {
       }
       await ensureDir(path.dirname(nodeOutputAbs));
 
-      const prompt = promptTemplateInline ? promptTemplateInline : await readTextFile(promptPathAbs);
+      const promptRaw = promptTemplateInline ? promptTemplateInline : await readTextFile(promptPathAbs);
+      // Inline `{{file:<relative-path>}}` contents so LLM nodes can see workspace files
+      // they cannot fetch themselves (llm-task is one-shot, no tool loop).
+      const prompt = await expandFileIncludes(promptRaw, teamDir);
       const task = [
         `You are executing a workflow run for teamId=${teamId}.`,
         `Workflow: ${workflow.name ?? workflow.id ?? workflowFile}`,

--- a/src/lib/workflows/workflow-utils.ts
+++ b/src/lib/workflows/workflow-utils.ts
@@ -158,6 +158,81 @@ export function templateReplace(input: string, vars: Record<string, string>) {
   return out;
 }
 
+export const FILE_INCLUDE_MAX_BYTES_DEFAULT = 256 * 1024;
+
+/**
+ * Expand `{{file:<relative-path>}}` markers by inlining the contents of files
+ * under the team workspace. Intended for LLM prompts where the model cannot
+ * call a read_file tool itself (workflow llm-task is one-shot, no tool loop).
+ *
+ * Safety:
+ *  - paths are treated as RELATIVE TO teamDir
+ *  - rejects absolute paths, paths with `..`, and paths that escape teamDir (incl. via symlink)
+ *  - enforces a per-include byte cap (default 256KB)
+ *
+ * On any rejection the marker is replaced with a short `[[file-include …]]`
+ * note so the LLM sees the failure context instead of the pipeline blowing up.
+ */
+export async function expandFileIncludes(
+  input: string,
+  teamDir: string,
+  opts: { maxBytes?: number } = {},
+): Promise<string> {
+  const text = String(input ?? '');
+  const pattern = /\{\{\s*file:([^}]+?)\s*\}\}/g;
+  const matches = Array.from(text.matchAll(pattern));
+  if (!matches.length) return text;
+
+  const maxBytes = opts.maxBytes ?? FILE_INCLUDE_MAX_BYTES_DEFAULT;
+  const teamDirResolvedRaw = path.resolve(teamDir);
+  // Resolve symlinks on teamDir too so comparisons below are apples-to-apples.
+  // On macOS, os.tmpdir() returns /var/... but realpath yields /private/var/... .
+  let teamDirResolved = teamDirResolvedRaw;
+  try { teamDirResolved = await fs.realpath(teamDirResolvedRaw); } catch { /* fall back to resolved */ }
+  const teamDirPrefix = teamDirResolved + path.sep;
+
+  const resolved = new Map<string, string>();
+  for (const m of matches) {
+    const rawPath = m[1].trim();
+    if (resolved.has(rawPath)) continue;
+
+    if (!rawPath || path.isAbsolute(rawPath) || rawPath.split('/').includes('..')) {
+      resolved.set(rawPath, `[[file-include rejected: unsafe path "${rawPath}"]]`);
+      continue;
+    }
+
+    const candidate = path.resolve(teamDirResolved, rawPath);
+    if (candidate !== teamDirResolved && !candidate.startsWith(teamDirPrefix)) {
+      resolved.set(rawPath, `[[file-include rejected: outside team workspace "${rawPath}"]]`);
+      continue;
+    }
+
+    try {
+      const real = await fs.realpath(candidate);
+      if (real !== teamDirResolved && !real.startsWith(teamDirPrefix)) {
+        resolved.set(rawPath, `[[file-include rejected: symlink escapes team workspace "${rawPath}"]]`);
+        continue;
+      }
+      const stat = await fs.stat(real);
+      if (!stat.isFile()) {
+        resolved.set(rawPath, `[[file-include rejected: not a regular file "${rawPath}"]]`);
+        continue;
+      }
+      if (stat.size > maxBytes) {
+        resolved.set(rawPath, `[[file-include rejected: "${rawPath}" size ${stat.size}B exceeds ${maxBytes}B cap]]`);
+        continue;
+      }
+      const content = await fs.readFile(real, 'utf8');
+      resolved.set(rawPath, content);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      resolved.set(rawPath, `[[file-include failed: "${rawPath}" — ${msg}]]`);
+    }
+  }
+
+  return text.replace(pattern, (_full, raw) => resolved.get(String(raw).trim()) ?? '');
+}
+
 export function sanitizeDraftOnlyText(text: string): string {
   // Back-compat: older workflow nodes mention 'draft only'.
   // New canonical sanitizer also strips other internal-only disclaimer lines.

--- a/src/lib/workflows/workflow-worker.ts
+++ b/src/lib/workflows/workflow-worker.ts
@@ -22,7 +22,7 @@ import {
   moveRunTicket, appendRunLog, writeRunFile, loadRunFile,
   runFilePathFor, nodeLabel,
   loadNodeStatesFromRun, pickNextRunnableNodeIndex,
-  sanitizeDraftOnlyText, templateReplace,
+  sanitizeDraftOnlyText, templateReplace, expandFileIncludes,
 } from './workflow-utils';
 
 /**
@@ -780,7 +780,10 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
       const promptRaw = promptTemplateInline ? promptTemplateInline : await readTextFile(promptPathAbs);
 
       const vars = await buildTemplateVars(teamDir, runsDir, runId, workflowFile, workflow);
-      const prompt = templateReplace(promptRaw, vars);
+      const promptVarsResolved = templateReplace(promptRaw, vars);
+      // Inline `{{file:<relative-path>}}` contents so LLM nodes can see workspace files
+      // they cannot fetch themselves (llm-task is one-shot, no tool loop).
+      const prompt = await expandFileIncludes(promptVarsResolved, teamDir);
 
       // Build output format instructions from outputFields when defined
       const nodeConfig = asRecord((node as unknown as Record<string, unknown>)['config']);
@@ -1240,7 +1243,8 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
       const vars = await buildTemplateVars(teamDir, runsDir, task.runId, workflowFile, workflow);
       // Add node-level vars that templateReplace doesn't normally include
       vars['node.id'] = node.id;
-      const prompt = templateReplace(promptTemplateRaw, vars);
+      const promptVarsResolved = templateReplace(promptTemplateRaw, vars);
+      const prompt = await expandFileIncludes(promptVarsResolved, teamDir);
       const outputRelPath = templateReplace(outputPathRaw, vars);
 
       const defaultNodeOutputRel = path.join('node-outputs', `${String(nodeIdx).padStart(3, '0')}-${node.id}.json`);

--- a/tests/template-file-inclusion.test.ts
+++ b/tests/template-file-inclusion.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expandFileIncludes, FILE_INCLUDE_MAX_BYTES_DEFAULT } from "../src/lib/workflows/workflow-utils";
+
+let teamDir: string;
+
+beforeEach(async () => {
+  teamDir = await fs.mkdtemp(path.join(os.tmpdir(), "fileinc-"));
+});
+
+afterEach(async () => {
+  await fs.rm(teamDir, { recursive: true, force: true });
+});
+
+describe("expandFileIncludes", () => {
+  test("passes through text with no markers unchanged", async () => {
+    const out = await expandFileIncludes("just some prompt text", teamDir);
+    expect(out).toBe("just some prompt text");
+  });
+
+  test("inlines a single file under teamDir", async () => {
+    await fs.mkdir(path.join(teamDir, "shared-context"), { recursive: true });
+    await fs.writeFile(path.join(teamDir, "shared-context", "calendar.md"), "CAL_BODY");
+    const out = await expandFileIncludes("before {{file:shared-context/calendar.md}} after", teamDir);
+    expect(out).toBe("before CAL_BODY after");
+  });
+
+  test("deduplicates repeated includes and still substitutes each occurrence", async () => {
+    await fs.writeFile(path.join(teamDir, "a.txt"), "A");
+    const out = await expandFileIncludes("{{file:a.txt}} | {{file:a.txt}}", teamDir);
+    expect(out).toBe("A | A");
+  });
+
+  test("tolerates whitespace inside the marker", async () => {
+    await fs.writeFile(path.join(teamDir, "a.txt"), "A");
+    const out = await expandFileIncludes("x {{ file:a.txt }} y", teamDir);
+    expect(out).toBe("x A y");
+  });
+
+  test("rejects absolute paths", async () => {
+    await fs.writeFile(path.join(teamDir, "a.txt"), "A");
+    const abs = path.resolve(teamDir, "a.txt");
+    const out = await expandFileIncludes(`x {{file:${abs}}} y`, teamDir);
+    expect(out).toContain("[[file-include rejected: unsafe path");
+  });
+
+  test("rejects paths containing ..", async () => {
+    await fs.writeFile(path.join(teamDir, "a.txt"), "A");
+    const out = await expandFileIncludes("{{file:../a.txt}}", teamDir);
+    expect(out).toContain("[[file-include rejected: unsafe path");
+  });
+
+  test("rejects missing files gracefully (does not throw)", async () => {
+    const out = await expandFileIncludes("{{file:nope.md}}", teamDir);
+    expect(out).toContain("[[file-include failed:");
+    expect(out).toContain("nope.md");
+  });
+
+  test("rejects directories", async () => {
+    await fs.mkdir(path.join(teamDir, "adir"));
+    const out = await expandFileIncludes("{{file:adir}}", teamDir);
+    expect(out).toContain("[[file-include rejected: not a regular file");
+  });
+
+  test("enforces a per-include size cap", async () => {
+    const big = "x".repeat(11);
+    await fs.writeFile(path.join(teamDir, "big.txt"), big);
+    const out = await expandFileIncludes("{{file:big.txt}}", teamDir, { maxBytes: 10 });
+    expect(out).toContain("exceeds 10B cap");
+  });
+
+  test("rejects symlinks that escape teamDir", async () => {
+    // Create a file outside teamDir and symlink it inside
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "outside-"));
+    try {
+      await fs.writeFile(path.join(outside, "secret.txt"), "LEAK");
+      await fs.symlink(path.join(outside, "secret.txt"), path.join(teamDir, "sym.txt"));
+      const out = await expandFileIncludes("{{file:sym.txt}}", teamDir);
+      expect(out).toContain("[[file-include rejected: symlink escapes team workspace");
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("default size cap is 256KB", () => {
+    expect(FILE_INCLUDE_MAX_BYTES_DEFAULT).toBe(256 * 1024);
+  });
+
+  test("does not re-expand {{...}} markers inside included content", async () => {
+    // File content is treated as opaque text; it should not be re-substituted.
+    await fs.writeFile(path.join(teamDir, "has-markers.txt"), "inner {{run.id}} marker");
+    const out = await expandFileIncludes("{{file:has-markers.txt}}", teamDir);
+    expect(out).toBe("inner {{run.id}} marker");
+  });
+
+  test("leaves unrelated marker shapes alone", async () => {
+    const out = await expandFileIncludes("{{notafile}} and {{file}}", teamDir);
+    expect(out).toBe("{{notafile}} and {{file}}");
+  });
+});


### PR DESCRIPTION
## Summary

Workflow llm-task is a one-shot JSON request with no tool-use loop — LLM nodes cannot follow "Read shared-context/…" instructions in their prompts even when the agent has `group:fs` access. Result: prompts that reference workspace files hallucinate content instead of sourcing it.

This PR adds `{{file:<relative-path>}}` syntax to workflow prompts. When the worker resolves the prompt, file markers are replaced with the contents of the named file under the team workspace. Safe against absolute paths, `..` traversal, and symlink escapes, with a 256KB per-include cap.

## Changes

- `src/lib/workflows/workflow-utils.ts` — new `expandFileIncludes(input, teamDir, opts?)`
- `src/lib/workflows/workflow-worker.ts` — called after `templateReplace` on LLM and media prompts
- `src/lib/workflows/workflow-node-executor.ts` — same, on the legacy LLM path
- `tests/template-file-inclusion.test.ts` — 13 new tests

Full test suite: **292 passed (47 files)**. No existing tests broken.

## Version

Bumped 0.4.57 → 0.4.58 (`package.json` + `openclaw.plugin.json`).

## Example

Before (empty string substituted):
```
{{driver_status_snapshot.stdout}}
```

After (real content inlined):
```
Monthly calendar (authoritative):
{{file:shared-context/calendars/current-approved-content-calendar.md}}
```

## Test plan

- [x] Local vitest suite passes
- [x] Hot-installed into `~/.openclaw/extensions/recipes/**`, gateway restarted
- [x] Verified live: weekly_selection LLM output matches seeded calendar (no hallucination) on run `2026-04-23t01-41-55-127z-94be2c20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)