### PR TITLE
Fix release version sync for plugin manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check plugin version sync
+        run: npm run check:plugin-version
+
       - name: Audit dependencies
         run: npm audit --audit-level=high
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version
-        run: npm version ${{ inputs.bump }}
+      - name: Bump version + sync plugin manifest
+        run: |
+          npm version ${{ inputs.bump }} --no-git-tag-version
+          npm run -s sync:plugin-version
+          npm run -s check:plugin-version
+          VERSION=$(node -p "require('./package.json').version")
+          git add package.json package-lock.json openclaw.plugin.json
+          git commit -m "$VERSION"
+          git tag "v$VERSION"
 
       - name: Push version commit + tag
         run: git push origin main --follow-tags

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "recipes",
   "name": "Recipes",
   "description": "Markdown recipes that scaffold agents and teams (workspace-local).",
-  "version": "0.4.58",
+  "version": "0.4.59",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
## Summary
- sync `openclaw.plugin.json` back to `0.4.59` on main
- fail CI when `package.json` and `openclaw.plugin.json` drift
- make the release workflow sync and commit the plugin manifest before tagging

## Why
The repo was able to publish a correct package artifact while leaving the source tree stale, which made it easier to poison local exact-version pins and confused source-based installs.

## Testing
- npm run check:plugin-version
- npm test
