### PR TITLE
Fix release workflow tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,13 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           git add package.json package-lock.json openclaw.plugin.json
           git commit -m "$VERSION"
-          git tag "v$VERSION"
+          git tag -a "v$VERSION" -m "$VERSION"
 
       - name: Push version commit + tag
-        run: git push origin main --follow-tags
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          git push origin main
+          git push origin "v$VERSION"
 
       - name: Pack tarball
         run: npm pack


### PR DESCRIPTION
## Summary
- create an annotated release tag in the workflow
- push the tag explicitly instead of relying on `--follow-tags`

## Why
The previous workflow created a lightweight local tag, so `git push --follow-tags` skipped it. That let the version-bump commit reach `main` while leaving the GitHub release step without a remote tag.

## Testing
- reviewed workflow logic
- confirmed failure mode from the failed `v0.4.60` run
