### PR TITLE
fix(workflow-worker): skip stale tasks for deleted runs instead of crashing the tick

### DIFF
--- a/src/lib/workflows/workflow-worker.ts
+++ b/src/lib/workflows/workflow-worker.ts
@@ -655,9 +655,16 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
         } else {
           // The lock is still live and held by another worker. The cursor has
           // already advanced past this task, so under naive logic we'd lose it.
-          // Re-enqueue — but ONLY if no equivalent task is already pending.
-          // Otherwise repeated ticks against a stuck lock would pile up dozens
-          // of duplicates for the same {runId, nodeId}.
+          // Re-enqueue — but ONLY if no equivalent task is already pending
+          // AND the run still exists. Without the run.json check, a lock-held
+          // task for a deleted run gets endlessly re-enqueued, crash-looping
+          // every tick that dequeues it.
+          const runStillExists = await fileExists(runFilePathFor(runsDir, task.runId));
+          if (!runStillExists) {
+            countedTowardLimit = false;
+            results.push({ taskId: task.id, runId: task.runId, nodeId: task.nodeId, status: 'skipped_stale' });
+            continue;
+          }
           const alreadyPending = await hasPendingTaskFor(teamDir, agentId, {
             runId: task.runId,
             nodeId: task.nodeId,
@@ -678,14 +685,35 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
 
       const runId = task.runId;
 
-      const { run } = await loadRunFile(teamDir, runsDir, runId);
-      const workflowFile = String(run.workflow.file);
-      const workflowPath = path.join(workflowsDir, workflowFile);
-      const workflowRaw = await readTextFile(workflowPath);
-      const workflow = normalizeWorkflow(JSON.parse(workflowRaw));
-
-      const nodeIdx = workflow.nodes.findIndex((n) => String(n.id) === String(task.nodeId));
-      if (nodeIdx < 0) throw new Error(`Node not found in workflow: ${task.nodeId}`);
+      // loadRunFile + workflow/node lookup can throw if the run dir was
+      // removed out from under us (manual cleanup, workspace reset) or if
+      // the workflow JSON renamed/removed this node between enqueue and
+      // dequeue. The outer try has only a finally, so a throw here would
+      // escape the tick and crash the CLI — which in a 1-minute cron loop
+      // means every subsequent tick dies the same way until an operator
+      // manually drains the queue. Skip stale instead.
+      let run: RunLog;
+      let workflow: ReturnType<typeof normalizeWorkflow>;
+      let workflowFile: string;
+      let nodeIdx: number;
+      try {
+        ({ run } = await loadRunFile(teamDir, runsDir, runId));
+        workflowFile = String(run.workflow.file);
+        const workflowPath = path.join(workflowsDir, workflowFile);
+        const workflowRaw = await readTextFile(workflowPath);
+        workflow = normalizeWorkflow(JSON.parse(workflowRaw));
+        nodeIdx = workflow.nodes.findIndex((n) => String(n.id) === String(task.nodeId));
+        if (nodeIdx < 0) throw new Error(`Node not found in workflow: ${task.nodeId}`);
+      } catch (err) {
+        countedTowardLimit = false;
+        // Log the reason so operators can diagnose; don't add it to the
+        // result shape (kept narrow for downstream consumers).
+        try {
+          console.warn(`[workflow-worker] skip_stale taskId=${task.id} runId=${task.runId} nodeId=${task.nodeId} reason=${(err as Error)?.message ?? String(err)}`);
+        } catch { /* log best-effort */ }
+        results.push({ taskId: task.id, runId: task.runId, nodeId: task.nodeId, status: 'skipped_stale' });
+        continue;
+      }
       const node = workflow.nodes[nodeIdx]!;
 
       // Now that we know the node, tighten the lock TTL based on node.config.timeoutMs.

--- a/tests/workflow-runner-file-first.test.ts
+++ b/tests/workflow-runner-file-first.test.ts
@@ -304,7 +304,19 @@ describe("workflow-runner (file-first + runner/worker)", () => {
         kind: "execute_node",
       });
 
-      const lockDir = path.join(teamDir, "shared-context", "workflow-runs", "run-lock", "locks");
+      // Seed a minimal run.json so the worker reaches the lock-contention
+      // branch. Without this, the "run.json missing" skip (added to guard
+      // against deleted runs) would short-circuit before we exercise the
+      // lock path this test cares about.
+      const runDir = path.join(teamDir, "shared-context", "workflow-runs", "run-lock");
+      await fs.mkdir(runDir, { recursive: true });
+      await fs.writeFile(
+        path.join(runDir, "run.json"),
+        JSON.stringify({ runId: "run-lock", ticket: { file: "", lane: "backlog" }, workflow: { file: "" }, status: "waiting_workers", events: [], nodeResults: [], nodeStates: {} }),
+        "utf8"
+      );
+
+      const lockDir = path.join(runDir, "locks");
       await fs.mkdir(lockDir, { recursive: true });
       const lockPath = path.join(lockDir, "node-lock.lock");
       await fs.writeFile(
@@ -1099,6 +1111,188 @@ describe("workflow-runner (file-first + runner/worker)", () => {
       expect(reparsed.mocked).toBe(true);
     } finally {
       llmResponseOverride.value = undefined;
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: when a run's run.json has been deleted (e.g., operator ran
+  // rm on the run dir, or the workspace got cleaned) but stale tasks for
+  // that run still sit in an agent queue, the worker used to throw from
+  // loadRunFile. That exception escaped the outer try (which only has a
+  // finally) and crashed the CLI. The next launchd tick would claim the
+  // next task and crash again. Fix: treat "run.json missing" as
+  // `skipped_stale`, NOT an error — so the tick drains the zombies and
+  // reaches real work behind them.
+  test("worker skips tasks for runs whose run.json was deleted (no crash)", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-deleted-run";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+    const shared = path.join(teamDir, "shared-context");
+    const workflowsDir = path.join(shared, "workflows");
+
+    try {
+      await fs.mkdir(workflowsDir, { recursive: true });
+      await fs.mkdir(path.join(teamDir, "work", "backlog"), { recursive: true });
+
+      const workflowFile = "deleted-run.workflow.json";
+      const workflowPath = path.join(workflowsDir, workflowFile);
+      const workflow = {
+        id: "deleted-run",
+        name: "Tasks for deleted runs must not crash the worker",
+        nodes: [
+          { id: "start", kind: "start" },
+          {
+            id: "do-work",
+            kind: "tool",
+            assignedTo: { agentId: "agent-shared" },
+            action: {
+              tool: "fs.append",
+              args: { path: "shared-context/REAL.log", content: "did real work\n" },
+            },
+          },
+          { id: "end", kind: "end" },
+        ],
+        edges: [
+          { from: "start", to: "do-work", on: "success" },
+          { from: "do-work", to: "end", on: "success" },
+        ],
+      };
+      await fs.writeFile(workflowPath, JSON.stringify(workflow, null, 2), "utf8");
+
+      const api = stubApi();
+
+      // Plant stale queue entries for a run whose run.json does NOT exist.
+      // This mimics what we see in prod after deleting a run dir while
+      // stale tasks sit in the agent queue.
+      for (let i = 0; i < 3; i++) {
+        await enqueueTask(teamDir, "agent-shared", {
+          teamId,
+          runId: "ghost-run-that-was-deleted",
+          nodeId: "do-work",
+          kind: "execute_node",
+        });
+      }
+
+      // Tick the worker. Old behavior: first ghost task crashes at
+      // loadRunFile; the exception escapes (outer try has only a finally)
+      // and the tick rejects. New behavior: loadRunFile's throw is
+      // caught, the task is recorded as skipped_stale, and the loop
+      // moves on to the next task.
+      const w = await runWorkflowWorkerTick(api, {
+        teamId,
+        agentId: "agent-shared",
+        limit: 10,
+        workerId: "w-ghost",
+      });
+      expect(w.ok).toBe(true);
+
+      const results = (w as { results: Array<{ status: string; runId: string; nodeId: string }> }).results;
+      const ghostSkipped = results.filter(
+        (r) => r.runId === "ghost-run-that-was-deleted" && r.status === "skipped_stale"
+      ).length;
+      expect(ghostSkipped).toBe(3);
+    } finally {
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: when a task is dequeued for a deleted run AND another worker
+  // holds the node lock (lock contention path), the worker used to re-enqueue
+  // the task — creating a permanent zombie. Fix: before re-enqueueing on
+  // lock contention, check that the run still exists. If not, drop it.
+  test("worker does not re-enqueue tasks for deleted runs on lock contention", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-zombie";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+    const shared = path.join(teamDir, "shared-context");
+    const workflowsDir = path.join(shared, "workflows");
+
+    try {
+      await fs.mkdir(workflowsDir, { recursive: true });
+      await fs.mkdir(path.join(teamDir, "work", "backlog"), { recursive: true });
+
+      const workflowFile = "zombie.workflow.json";
+      const workflowPath = path.join(workflowsDir, workflowFile);
+      const workflow = {
+        id: "zombie",
+        name: "Zombie tasks for deleted runs must not be re-enqueued",
+        nodes: [
+          { id: "start", kind: "start" },
+          {
+            id: "work",
+            kind: "tool",
+            assignedTo: { agentId: "agent-z" },
+            action: { tool: "fs.append", args: { path: "shared-context/Z.log", content: "z\n" } },
+          },
+          { id: "end", kind: "end" },
+        ],
+        edges: [
+          { from: "start", to: "work", on: "success" },
+          { from: "work", to: "end", on: "success" },
+        ],
+      };
+      await fs.writeFile(workflowPath, JSON.stringify(workflow, null, 2), "utf8");
+
+      const api = stubApi();
+
+      // Plant a queue task for a run that never existed.
+      await enqueueTask(teamDir, "agent-z", {
+        teamId,
+        runId: "never-existed-run",
+        nodeId: "work",
+        kind: "execute_node",
+      });
+
+      // Plant a fresh live lock for the deleted run's node so the worker
+      // takes the lock-contention branch (which is the original re-enqueue
+      // site).
+      const lockDir = path.join(shared, "workflow-runs", "never-existed-run", "locks");
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(
+        path.join(lockDir, "work.lock"),
+        JSON.stringify({
+          workerId: "other-worker",
+          pid: 999999,
+          taskId: "other-task",
+          claimedAt: new Date().toISOString(),
+          ttlMs: 30 * 60 * 1000,
+          expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+        }),
+        "utf8"
+      );
+
+      const queuePath = path.join(shared, "workflow-queues", "agent-z.jsonl");
+      const queueBytesBefore = (await fs.readFile(queuePath, "utf8")).length;
+
+      const w = await runWorkflowWorkerTick(api, {
+        teamId,
+        agentId: "agent-z",
+        limit: 5,
+        workerId: "w-zombie",
+      });
+      expect(w.ok).toBe(true);
+
+      // The queue MUST NOT have grown — the task for the deleted run should
+      // have been dropped (status=skipped_stale), not re-enqueued.
+      const queueBytesAfter = (await fs.readFile(queuePath, "utf8")).length;
+      expect(queueBytesAfter).toBe(queueBytesBefore);
+
+      const results = (w as { results: Array<{ status: string; runId: string }> }).results;
+      const stale = results.filter(
+        (r) => r.runId === "never-existed-run" && r.status === "skipped_stale"
+      );
+      expect(stale.length).toBeGreaterThanOrEqual(1);
+    } finally {
       process.env.OPENCLAW_WORKSPACE = prevWorkspace;
       await fs.rm(base, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Two compounding failure modes created a tick crash loop in production when run dirs were cleaned while stale queue entries remained:

1. **`loadRunFile` threw into a bare `finally`.** The outer per-task try at `workflow-worker.ts:592` has no catch — only a `finally` at 1687 for lock/claim cleanup. When `loadRunFile` threw \"Run file not found\" for a deleted run, the exception escaped and killed the whole worker-tick. Under 1-minute launchd cadence, every subsequent tick dequeued the next stale task and crashed the same way until an operator manually drained the queue.
2. **Lock-contention re-enqueue resurrected deleted runs.** When a lock is held by another worker, we re-enqueue the task so it isn't lost. If the run was deleted while the lock was held, the task becomes a permanent zombie — re-enqueued forever.

## Changes

- Wrap `loadRunFile` + workflow/node lookup in try/catch that logs the reason and records `skipped_stale` (matching the existing taxonomy used when nodes have already advanced past success/error).
- Before re-enqueueing on lock contention, `fileExists(runFilePathFor(...))` check. If the run is gone, drop the task as `skipped_stale`.

## Tests

- **New**: worker skips stale tasks for deleted runs without crashing the tick (asserts `skipped_stale` for 3 ghost tasks, no throw, `w.ok === true`)
- **New**: worker does not re-enqueue tasks for deleted runs on lock contention (asserts queue byte size doesn't grow, exactly the failure mode observed in prod)
- **Fixed**: existing \`releases claim when lock contention causes requeue\` test was implicitly depending on the old bug — it planted a lock for a run whose run.json never existed. Updated to seed a minimal run.json so the lock-contention path is the one being exercised.

All 294 tests pass.

## Test plan

- [x] `vitest run` — 294/294 passing
- [ ] After merge + release, bump local extension in `~/.openclaw/extensions/recipes/` and verify no more `[openclaw] Failed to start CLI: Run file not found` in `~/.openclaw/logs/cron/com.hairmx.workflow-worker.*.err.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)