### PR TITLE
fix(toolsInvoke): honor per-call args.timeoutMs on fetch abort timer

### DIFF
--- a/src/toolsInvoke.ts
+++ b/src/toolsInvoke.ts
@@ -47,7 +47,15 @@ function parseToolsInvokeError(json: ToolsInvokeResponse, status: number): strin
 
 async function doSingleToolsInvoke<T>(url: string, token: string, req: ToolsInvokeRequest): Promise<T> {
   const ac = new AbortController();
-  const t = setTimeout(() => ac.abort(), TOOLS_INVOKE_TIMEOUT_MS);
+  // Honor per-call timeoutMs (e.g. LLM nodes often pass 300000-900000 ms).
+  // Add a 30s HTTP/gateway overhead buffer so the LLM has the full node-
+  // configured window to produce its response before the fetch aborts.
+  // Fall back to the module default when no timeout was passed.
+  const argsTimeout = typeof (req.args as Record<string, unknown> | undefined)?.['timeoutMs'] === 'number'
+    ? (req.args as { timeoutMs: number }).timeoutMs
+    : 0;
+  const fetchTimeoutMs = argsTimeout > 0 ? argsTimeout + 30_000 : TOOLS_INVOKE_TIMEOUT_MS;
+  const t = setTimeout(() => ac.abort(), fetchTimeoutMs);
   const res = await fetch(url, {
     method: "POST",
     signal: ac.signal,

--- a/tests/toolsInvoke.test.ts
+++ b/tests/toolsInvoke.test.ts
@@ -58,4 +58,50 @@ describe("toolsInvoke", () => {
     expect(result).toEqual({ success: true });
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
+
+  test("uses args.timeoutMs + 30s buffer for fetch abort timer when provided", async () => {
+    // Workflow LLM nodes pass timeoutMs in args (e.g. 900_000 for the weekly
+    // packet draft). Before this fix, the fetch was hardcoded at 120s and
+    // aborted long-running LLM calls even though the node config said 15 min.
+    const delays: number[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    vi.stubGlobal("setTimeout", (fn: () => void, delay: number) => {
+      delays.push(delay);
+      return realSetTimeout(fn, delay);
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, result: { ok: true } }),
+      })
+    );
+    const api = { config: { gateway: { port: 18789, auth: { token: "secret" } } } };
+    await toolsInvoke(api, {
+      tool: "llm-task",
+      action: "json",
+      args: { prompt: "x", timeoutMs: 900_000 },
+    });
+    // 900_000 + 30_000 buffer for HTTP roundtrip/gateway overhead
+    expect(delays).toContain(930_000);
+  });
+
+  test("falls back to default TOOLS_INVOKE_TIMEOUT_MS when args.timeoutMs missing", async () => {
+    const delays: number[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    vi.stubGlobal("setTimeout", (fn: () => void, delay: number) => {
+      delays.push(delay);
+      return realSetTimeout(fn, delay);
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, result: { ok: true } }),
+      })
+    );
+    const api = { config: { gateway: { port: 18789, auth: { token: "secret" } } } };
+    await toolsInvoke(api, { tool: "cron", args: { action: "list" } });
+    expect(delays).toContain(TOOLS_INVOKE_TIMEOUT_MS);
+  });
 });


### PR DESCRIPTION
## Summary

The fetch abort timer in \`toolsInvoke\` was hardcoded at \`TOOLS_INVOKE_TIMEOUT_MS = 120_000\`, ignoring any \`timeoutMs\` passed in \`args\`. Workflow LLM nodes commonly set \`args.timeoutMs\` to 300–900 seconds to allow for large prompts + long generations, but the outer fetch would abort at 2 min regardless — surfacing as \`AbortError: This operation was aborted\` in run state and burning ~15 min on retry cascades before the run finally errored.

## Repro (observed in prod)

- \`weekly_packet_draft\` node with \`config.timeoutMs: 900000\` (15 min)
- Prompt ~17 KB (brand-voice + content-ops + template file includes)
- Model: \`anthropic/claude-opus-4-7\` — typical response 90–240s for a 12KB markdown packet
- Before: fetch aborts at 120s; retries 3x then errors out after 14-15 min
- After: fetch uses \`900000 + 30000 = 930000 ms\`; LLM completes within the window

## Fix

\`\`\`ts
const argsTimeout = typeof req.args?.timeoutMs === 'number'
  ? req.args.timeoutMs
  : 0;
const fetchTimeoutMs = argsTimeout > 0
  ? argsTimeout + 30_000  // 30s HTTP/gateway overhead buffer
  : TOOLS_INVOKE_TIMEOUT_MS;
\`\`\`

## Test plan

- [x] \`vitest run\` — 296/296 passing
- New unit tests cover both the args-timeout path (+30s buffer) and the default fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)