### PR TITLE
fix(workflow-worker): surface tool stdout as .text for downstream template vars

### DIFF
--- a/src/lib/workflows/workflow-worker.ts
+++ b/src/lib/workflows/workflow-worker.ts
@@ -1112,6 +1112,10 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
       const artifactsDir = path.join(runDir, 'artifacts');
       await ensureDir(artifactsDir);
       const artifactPath = path.join(artifactsDir, `${String(nodeIdx).padStart(3, '0')}-${node.id}.tool.json`);
+      // Captures the "human-readable output" each tool produced so the post-
+      // branch code can surface it as `.text` in the node-output file for
+      // downstream `{{nodeId.field}}` templating. Each branch sets this.
+      let toolOutputText = '';
       try {
         // Runner-native tools (preferred): do NOT depend on gateway tool exposure.
         if (toolName === 'fs.append') {
@@ -1135,6 +1139,7 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
 
           const result = { appendedTo: path.relative(teamDir, abs), bytes: Buffer.byteLength(content, 'utf8') };
           await fs.writeFile(artifactPath, JSON.stringify({ ok: true, tool: toolName, args: toolArgs, result }, null, 2) + '\n', 'utf8');
+          toolOutputText = JSON.stringify(result);
 
         } else if (toolName === 'fs.write') {
           const relPathRaw = String(toolArgs.path ?? '').trim();
@@ -1155,6 +1160,7 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
 
           const result = { writtenTo: path.relative(teamDir, abs), bytes: Buffer.byteLength(content, 'utf8') };
           await fs.writeFile(artifactPath, JSON.stringify({ ok: true, tool: toolName, args: toolArgs, result }, null, 2) + '\n', 'utf8');
+          toolOutputText = JSON.stringify(result);
 
         } else {
           const vars = await buildTemplateVars(teamDir, runsDir, runId, workflowFile, workflow);
@@ -1211,6 +1217,18 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
           }
 
           await fs.writeFile(artifactPath, JSON.stringify({ ok: true, tool: toolName, args: processedToolArgs, result: toolRes }, null, 2) + '\n', 'utf8');
+
+          // Surface tool output as `.text` so downstream `{{nodeId.field}}`
+          // templating resolves. For `exec`, use stdout (commonly JSON emitted
+          // by a script, which buildTemplateVars parses into per-field vars).
+          // For other tools, use the raw string or stringified object.
+          if (toolName === 'exec' && toolRes && typeof toolRes === 'object' && 'stdout' in (toolRes as Record<string, unknown>)) {
+            toolOutputText = String((toolRes as { stdout?: unknown }).stdout ?? '').trim();
+          } else if (typeof toolRes === 'string') {
+            toolOutputText = toolRes;
+          } else {
+            toolOutputText = JSON.stringify(toolRes, null, 2);
+          }
         }
 
         const defaultNodeOutputRel = path.join('node-outputs', `${String(nodeIdx).padStart(3, '0')}-${node.id}.json`);
@@ -1224,6 +1242,7 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
           kind: node.kind,
           completedAt: new Date().toISOString(),
           tool: toolName,
+          text: toolOutputText,
           artifactPath: path.relative(teamDir, artifactPath),
         }, null, 2) + '\n', 'utf8');
 

--- a/tests/workflow-runner-file-first.test.ts
+++ b/tests/workflow-runner-file-first.test.ts
@@ -1297,4 +1297,102 @@ describe("workflow-runner (file-first + runner/worker)", () => {
       await fs.rm(base, { recursive: true, force: true });
     }
   });
+
+  // Regression: exec tool nodes must surface their stdout as `.text` in the
+  // node-output so downstream `{{nodeId.field}}` templating resolves. Prior
+  // bug left exec stdout only in the artifact file; downstream exec commands
+  // like `curl "...?team={{select_account.kitchenTeamId}}"` received the
+  // literal `{{…}}` placeholder and failed.
+  test("exec tool stdout becomes node .text, enabling downstream template vars", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-exec-text";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+    const shared = path.join(teamDir, "shared-context");
+    const workflowsDir = path.join(shared, "workflows");
+
+    try {
+      await fs.mkdir(workflowsDir, { recursive: true });
+      await fs.mkdir(path.join(teamDir, "work", "backlog"), { recursive: true });
+
+      const workflowFile = "exec-text.workflow.json";
+      const workflowPath = path.join(workflowsDir, workflowFile);
+      const workflow = {
+        id: "exec-text",
+        name: "exec stdout → .text → downstream template var",
+        nodes: [
+          { id: "start", kind: "start" },
+          {
+            id: "producer",
+            kind: "tool",
+            assignedTo: { agentId: "agent-a" },
+            action: {
+              tool: "exec",
+              args: { command: `echo '{"kitchenTeamId":"hmx-marketing-team","mediaUrl":"/m/42.png"}'` },
+            },
+          },
+          {
+            id: "consumer",
+            kind: "tool",
+            assignedTo: { agentId: "agent-a" },
+            action: {
+              tool: "fs.append",
+              args: {
+                path: "shared-context/consumer.log",
+                content: "team={{producer.kitchenTeamId}} media={{producer.mediaUrl}}\n",
+              },
+            },
+          },
+          { id: "end", kind: "end" },
+        ],
+        edges: [
+          { from: "start", to: "producer", on: "success" },
+          { from: "producer", to: "consumer", on: "success" },
+          { from: "consumer", to: "end", on: "success" },
+        ],
+      };
+      await fs.writeFile(workflowPath, JSON.stringify(workflow, null, 2), "utf8");
+
+      // Stub api.runtime.system.runCommandWithTimeout so the exec path works
+      // in-test without spawning a real process.
+      const api = stubApi() as unknown as { runtime?: Record<string, unknown>; config: Record<string, unknown> };
+      api.runtime = {
+        system: {
+          runCommandWithTimeout: async () => ({
+            stdout: '{"kitchenTeamId":"hmx-marketing-team","mediaUrl":"/m/42.png"}\n',
+            stderr: "",
+            code: 0,
+          }),
+        },
+      };
+
+      const enq = await enqueueWorkflowRun(api as unknown as OpenClawPluginApi, { teamId, workflowFile });
+      expect(enq.ok).toBe(true);
+      await runWorkflowRunnerOnce(api as unknown as OpenClawPluginApi, { teamId });
+      await runWorkflowWorkerTick(api as unknown as OpenClawPluginApi, { teamId, agentId: "agent-a", limit: 5, workerId: "w" });
+
+      // Node-output for the exec node should contain .text = the stdout
+      const runDir = path.join(shared, "workflow-runs");
+      const runs = await fs.readdir(runDir);
+      const producerOut = JSON.parse(
+        await fs.readFile(path.join(runDir, runs[0]!, "node-outputs", "001-producer.json"), "utf8")
+      ) as { text?: string };
+      expect(producerOut.text).toBeDefined();
+      expect(producerOut.text).toContain("kitchenTeamId");
+      expect(JSON.parse(producerOut.text!)).toEqual({
+        kitchenTeamId: "hmx-marketing-team",
+        mediaUrl: "/m/42.png",
+      });
+
+      // Downstream fs.append should have resolved {{producer.kitchenTeamId}}
+      // and {{producer.mediaUrl}} from the parsed .text JSON.
+      const appended = await fs.readFile(path.join(shared, "consumer.log"), "utf8");
+      expect(appended.trim()).toBe("team=hmx-marketing-team media=/m/42.png");
+    } finally {
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Tool nodes (exec, fs.append, fs.write, and gateway-invoked tools) wrote their output ONLY to the artifact file. The node-output file contained just metadata (\`nodeId\`, \`tool\`, \`artifactPath\`) with **no \`text\` field**. When a downstream node referenced \`{{producer.field}}\`, \`buildTemplateVars\` read the node-output, didn't find a \`text\` to parse, and the placeholder remained literal.

## Repro from prod

The social-execution workflows use \`exec\` nodes to select an account and then curl to the kitchen API:

\`\`\`bash
# node: select_account (exec) — stdout is JSON:
# {\"kitchenTeamId\":\"hmx-marketing-team\",\"mediaUrl\":\"/m/42.png\",...}

# node: store_and_publish (exec) command:
curl \"...media?team={{select_account.kitchenTeamId}}\"
\`\`\`

\`{{select_account.kitchenTeamId}}\` resolved to literal \`{{…}}\`, curl rejected with:

\`\`\`
curl: (3) nested brace in URL position 63:
http://…/media?team={{select_account.kitchenTeamId}}
\`\`\`

All 4 platform publishing workflows (instagram, facebook, tiktok, google-business) errored on this path.

## Fix

Populate \`.text\` on every tool node output, mirroring the LLM-node contract:

- **exec**: \`stdout\` — usually JSON from a script, which \`buildTemplateVars\` parses and exposes each key as \`{{nodeId.key}}\`
- **fs.append / fs.write**: the result summary (\`{appendedTo|writtenTo, bytes}\`) stringified
- **gateway-invoked**: the raw string result or stringified payload

## Test plan

- [x] New regression test \"exec tool stdout becomes node .text, enabling downstream template vars\" — end-to-end producer (exec outputs JSON) → consumer (fs.append with \`{{producer.kitchenTeamId}}\` + \`{{producer.mediaUrl}}\` templates)
- [x] Full suite 297/297 passing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)