### PR TITLE
fix(workflow-worker): reclaim node lock when same-host PID is dead

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "recipes",
   "name": "Recipes",
   "description": "Markdown recipes that scaffold agents and teams (workspace-local).",
-  "version": "0.4.65",
+  "version": "0.4.66",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/recipes",
-  "version": "0.4.65",
+  "version": "0.4.66",
   "description": "ClawRecipes plugin for OpenClaw (markdown recipes -> scaffold agents/teams)",
   "main": "index.ts",
   "type": "commonjs",

--- a/src/lib/workflows/workflow-worker.ts
+++ b/src/lib/workflows/workflow-worker.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
@@ -598,6 +599,7 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
       const lockInfo = {
         workerId,
         pid: process.pid,
+        host: os.hostname(),
         taskId: task.id,
         claimedAt: claimedAtIso,
         ttlMs: DEFAULT_LOCK_TTL_MS,
@@ -614,7 +616,7 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
         let unlocked = false;
         try {
           const raw = await readTextFile(lockPath);
-          const parsed = JSON.parse(raw) as { claimedAt?: string; ttlMs?: number; expiresAt?: string };
+          const parsed = JSON.parse(raw) as { claimedAt?: string; ttlMs?: number; expiresAt?: string; host?: string; pid?: number };
 
           const expiresAtMs = parsed?.expiresAt ? Date.parse(String(parsed.expiresAt)) : NaN;
           const claimedAtMs = parsed?.claimedAt ? Date.parse(String(parsed.claimedAt)) : NaN;
@@ -635,7 +637,34 @@ export async function runWorkflowWorkerTick(api: OpenClawPluginApi, opts: {
                 : NaN;
 
           const stale = Number.isFinite(effectiveExpiryMs) && Date.now() > effectiveExpiryMs;
-          if (stale) {
+
+          // Same-host PID liveness check. If the lock recorded a host that
+          // matches ours and a pid that is no longer alive, the holder
+          // crashed or was killed; reclaim now instead of waiting out the
+          // full TTL (which can be tens of minutes for long LLM nodes).
+          //
+          // Cross-host locks are NEVER reclaimed via PID check — a remote
+          // PID may collide with a live local PID and produce a false
+          // "alive" reading, but we'd rather under-reclaim than steal a
+          // legitimately-held lock from another machine.
+          //
+          // Locks lacking host or pid (older format) skip this branch and
+          // fall through to TTL-only behavior.
+          let dead = false;
+          const sameHost = typeof parsed?.host === 'string' && parsed.host === os.hostname();
+          const lockPid = typeof parsed?.pid === 'number' && Number.isFinite(parsed.pid) ? parsed.pid : NaN;
+          if (sameHost && Number.isFinite(lockPid) && lockPid > 0) {
+            try {
+              process.kill(lockPid, 0);
+              // Process exists; treat lock as held.
+            } catch (err) {
+              if ((err as NodeJS.ErrnoException)?.code === 'ESRCH') dead = true;
+              // EPERM means the process exists but we can't signal it (e.g.,
+              // owned by another user); fall through to TTL-only behavior.
+            }
+          }
+
+          if (stale || dead) {
             await fs.unlink(lockPath);
             unlocked = true;
           }

--- a/tests/workflow-runner-file-first.test.ts
+++ b/tests/workflow-runner-file-first.test.ts
@@ -4,6 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
+// PID well above kern.pidmax on macOS (~99999) and Linux pid_max (~4194304).
+// process.kill(DEAD_PID_SENTINEL, 0) returns ESRCH on every supported host,
+// so we can use it to simulate "lock holder is gone" without spawning a real
+// child (which would trip the install-time skill-scanner's child_process rule).
+const DEAD_PID_SENTINEL = 2_147_483_646;
+
 const toolCalls: Array<{ tool: string; args?: any; action?: string }> = [];
 
 // Per-test override for what the mocked llm-task should return. Reset between tests.
@@ -333,6 +339,229 @@ describe("workflow-runner (file-first + runner/worker)", () => {
       const claimsDir = path.join(teamDir, "shared-context", "workflow-queues", "claims");
       const claimFiles = await fs.readdir(claimsDir).catch(() => []);
       expect(claimFiles.length).toBe(0);
+    } finally {
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test("worker reclaims lock when same-host PID is dead even within TTL window", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-lock-deadpid";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+
+    try {
+      await enqueueTask(teamDir, "agent-a", {
+        teamId,
+        runId: "run-deadpid",
+        nodeId: "node-x",
+        kind: "execute_node",
+      });
+
+      // Minimal run.json so we get past the run-existence guard. workflow.file
+      // is empty so that AFTER lock reclaim, the workflow load throws and the
+      // tick reports skipped_stale — distinguishing reclaim-and-fail from
+      // skipped_locked.
+      const runDir = path.join(teamDir, "shared-context", "workflow-runs", "run-deadpid");
+      await fs.mkdir(runDir, { recursive: true });
+      await fs.writeFile(
+        path.join(runDir, "run.json"),
+        JSON.stringify({ runId: "run-deadpid", ticket: { file: "", lane: "backlog" }, workflow: { file: "" }, status: "waiting_workers", events: [], nodeResults: [], nodeStates: {} }),
+        "utf8"
+      );
+
+      const lockDir = path.join(runDir, "locks");
+      await fs.mkdir(lockDir, { recursive: true });
+      const lockPath = path.join(lockDir, "node-x.lock");
+
+      const deadPid = DEAD_PID_SENTINEL;
+      const claimedAt = new Date();
+      const expiresAt = new Date(Date.now() + 17 * 60 * 1000); // TTL not expired
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          workerId: "kitchen-run-now",
+          pid: deadPid,
+          host: os.hostname(),
+          taskId: "previous-task",
+          claimedAt: claimedAt.toISOString(),
+          ttlMs: 17 * 60 * 1000,
+          expiresAt: expiresAt.toISOString(),
+        }, null, 2),
+        "utf8"
+      );
+
+      const api = stubApi();
+      const w1 = await runWorkflowWorkerTick(api, { teamId, agentId: "agent-a", limit: 1, workerId: "worker-a" });
+      expect(w1.ok).toBe(true);
+      // Reclaim succeeds, then workflow load fails because workflow.file is "".
+      // skipped_stale (not skipped_locked) proves the lock was reclaimed.
+      expect(w1.results[0]?.status).toBe("skipped_stale");
+      // Lock is released by the finally block after execution falls through.
+      const lockExists = await fs.stat(lockPath).then(() => true).catch(() => false);
+      expect(lockExists).toBe(false);
+    } finally {
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test("worker respects lock when same-host PID is alive within TTL window", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-lock-alivepid";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+
+    try {
+      await enqueueTask(teamDir, "agent-a", {
+        teamId,
+        runId: "run-alivepid",
+        nodeId: "node-x",
+        kind: "execute_node",
+      });
+
+      const runDir = path.join(teamDir, "shared-context", "workflow-runs", "run-alivepid");
+      await fs.mkdir(runDir, { recursive: true });
+      await fs.writeFile(
+        path.join(runDir, "run.json"),
+        JSON.stringify({ runId: "run-alivepid", ticket: { file: "", lane: "backlog" }, workflow: { file: "" }, status: "waiting_workers", events: [], nodeResults: [], nodeStates: {} }),
+        "utf8"
+      );
+
+      const lockDir = path.join(runDir, "locks");
+      await fs.mkdir(lockDir, { recursive: true });
+      const lockPath = path.join(lockDir, "node-x.lock");
+
+      // The current test process is guaranteed alive — use it as the lock holder.
+      const lockBody = JSON.stringify({
+        workerId: "kitchen-run-now",
+        pid: process.pid,
+        host: os.hostname(),
+        taskId: "previous-task",
+        claimedAt: new Date().toISOString(),
+        ttlMs: 17 * 60 * 1000,
+        expiresAt: new Date(Date.now() + 17 * 60 * 1000).toISOString(),
+      }, null, 2);
+      await fs.writeFile(lockPath, lockBody, "utf8");
+
+      const api = stubApi();
+      const w1 = await runWorkflowWorkerTick(api, { teamId, agentId: "agent-a", limit: 1, workerId: "worker-a" });
+      expect(w1.ok).toBe(true);
+      expect(w1.results[0]?.status).toBe("skipped_locked");
+      // Original lock content is preserved.
+      const after = await fs.readFile(lockPath, "utf8");
+      expect(after).toBe(lockBody);
+    } finally {
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test("worker does not check PID liveness when lock host differs", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-lock-otherhost";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+
+    try {
+      await enqueueTask(teamDir, "agent-a", {
+        teamId,
+        runId: "run-otherhost",
+        nodeId: "node-x",
+        kind: "execute_node",
+      });
+
+      const runDir = path.join(teamDir, "shared-context", "workflow-runs", "run-otherhost");
+      await fs.mkdir(runDir, { recursive: true });
+      await fs.writeFile(
+        path.join(runDir, "run.json"),
+        JSON.stringify({ runId: "run-otherhost", ticket: { file: "", lane: "backlog" }, workflow: { file: "" }, status: "waiting_workers", events: [], nodeResults: [], nodeStates: {} }),
+        "utf8"
+      );
+
+      const lockDir = path.join(runDir, "locks");
+      await fs.mkdir(lockDir, { recursive: true });
+      const lockPath = path.join(lockDir, "node-x.lock");
+
+      const deadPid = DEAD_PID_SENTINEL;
+      const lockBody = JSON.stringify({
+        workerId: "kitchen-run-now",
+        pid: deadPid,
+        host: `${os.hostname()}-not`,
+        taskId: "previous-task",
+        claimedAt: new Date().toISOString(),
+        ttlMs: 17 * 60 * 1000,
+        expiresAt: new Date(Date.now() + 17 * 60 * 1000).toISOString(),
+      }, null, 2);
+      await fs.writeFile(lockPath, lockBody, "utf8");
+
+      const api = stubApi();
+      const w1 = await runWorkflowWorkerTick(api, { teamId, agentId: "agent-a", limit: 1, workerId: "worker-a" });
+      expect(w1.ok).toBe(true);
+      expect(w1.results[0]?.status).toBe("skipped_locked");
+      const after = await fs.readFile(lockPath, "utf8");
+      expect(after).toBe(lockBody);
+    } finally {
+      process.env.OPENCLAW_WORKSPACE = prevWorkspace;
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test("worker falls back to TTL-only when lock has no host/pid (older format)", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+
+    const { base, workspaceRoot } = await mkTmpWorkspace();
+    process.env.OPENCLAW_WORKSPACE = workspaceRoot;
+
+    const teamId = "t-lock-legacy";
+    const teamDir = path.join(base, `workspace-${teamId}`);
+
+    try {
+      await enqueueTask(teamDir, "agent-a", {
+        teamId,
+        runId: "run-legacy",
+        nodeId: "node-x",
+        kind: "execute_node",
+      });
+
+      const runDir = path.join(teamDir, "shared-context", "workflow-runs", "run-legacy");
+      await fs.mkdir(runDir, { recursive: true });
+      await fs.writeFile(
+        path.join(runDir, "run.json"),
+        JSON.stringify({ runId: "run-legacy", ticket: { file: "", lane: "backlog" }, workflow: { file: "" }, status: "waiting_workers", events: [], nodeResults: [], nodeStates: {} }),
+        "utf8"
+      );
+
+      const lockDir = path.join(runDir, "locks");
+      await fs.mkdir(lockDir, { recursive: true });
+      const lockPath = path.join(lockDir, "node-x.lock");
+
+      // Older-format lock: no host, no pid, TTL not expired.
+      const lockBody = JSON.stringify({
+        workerId: "older-worker",
+        taskId: "previous-task",
+        claimedAt: new Date().toISOString(),
+        ttlMs: 17 * 60 * 1000,
+        expiresAt: new Date(Date.now() + 17 * 60 * 1000).toISOString(),
+      }, null, 2);
+      await fs.writeFile(lockPath, lockBody, "utf8");
+
+      const api = stubApi();
+      const w1 = await runWorkflowWorkerTick(api, { teamId, agentId: "agent-a", limit: 1, workerId: "worker-a" });
+      expect(w1.ok).toBe(true);
+      expect(w1.results[0]?.status).toBe("skipped_locked");
+      const after = await fs.readFile(lockPath, "utf8");
+      expect(after).toBe(lockBody);
     } finally {
       process.env.OPENCLAW_WORKSPACE = prevWorkspace;
       await fs.rm(base, { recursive: true, force: true });

--- a/tests/workflow-runner-file-first.test.ts
+++ b/tests/workflow-runner-file-first.test.ts
@@ -4,10 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
-// PID well above kern.pidmax on macOS (~99999) and Linux pid_max (~4194304).
-// process.kill(DEAD_PID_SENTINEL, 0) returns ESRCH on every supported host,
-// so we can use it to simulate "lock holder is gone" without spawning a real
-// child (which would trip the install-time skill-scanner's child_process rule).
+// PID well above kern.pidmax on macOS (~99999) and the default
+// kernel.pid_max on modern Linux (~4194304). process.kill(pid, 0) returns
+// ESRCH for unallocated pids, so this sentinel reliably simulates "lock
+// holder is gone" without spawning a real child (which would trip the
+// install-time skill-scanner's child_process rule). A custom kernel with
+// PID_MAX_LIMIT raised closer to INT32_MAX could in theory invalidate
+// this; if CI ever runs on such a kernel, switch to a runtime probe.
 const DEAD_PID_SENTINEL = 2_147_483_646;
 
 const toolCalls: Array<{ tool: string; args?: any; action?: string }> = [];


### PR DESCRIPTION
## Summary

- Node-level locks already carry a TTL derived from each node's configured `timeoutMs` plus a 2-minute buffer. For long LLM nodes (e.g. `weekly_packet_draft` with `timeoutMs: 900000`) that ceiling lands at **17 minutes**.
- Before this PR, the only stale-detection signal was TTL expiry. When a worker crashed mid-node — common with the `kitchen-run-now` one-shot path — the lock blocked every retry for the full TTL even though the holder was clearly gone.
- This PR adds a **same-host PID liveness check** alongside the TTL check. The lock file now records `host: os.hostname()` at claim time. On contention, if `parsed.host === os.hostname()` and `process.kill(parsed.pid, 0)` returns `ESRCH`, the holder is dead and we reclaim immediately.

## Why same-host only

PIDs are not unique across machines. A remote PID may collide with a live local PID and produce a false `alive` reading, or — worse — a remote-but-still-running worker's PID may not exist locally and produce a false `dead` reading that steals the lock from another machine. Restricting the check to same-host eliminates both. Locks lacking `host` or `pid` (older format) fall back to TTL-only behavior, preserving backward compatibility.

`EPERM` from `process.kill` (target exists but we can't signal it — e.g. owned by another user) is also treated as alive, so we never reclaim a lock from a process we just lack permission to inspect.

## Tests

Four new tests in `tests/workflow-runner-file-first.test.ts`:

- **Reclaims** when same-host PID is dead within TTL window — the new path.
- **Respects** lock when same-host PID is alive within TTL window — uses `process.pid` of the test runner itself.
- **Does not check liveness** when lock host differs from `os.hostname()` — guards against cross-host false positives.
- **Falls back to TTL-only** when lock has no host/pid (older format) — backward compat.

The "dead PID" tests use a sentinel `2_147_483_646` (well above macOS `kern.pidmax` ~99999 and Linux `pid_max` ~4194304) so `process.kill(pid, 0)` reliably returns `ESRCH`. This avoids spawning a real child process, which would trip the install-time skill-scanner's `dangerous-exec` rule.

All 301 tests pass.

## Test plan

- [x] `npx vitest run tests/workflow-runner-file-first.test.ts` — 7 lock-related tests pass; full suite green.
- [x] Smoke: `openclaw recipes workflows worker-tick --team-id hmx-marketing-team --agent-id hmx-marketing-team-copywriter --limit 1 --worker-id smoke-test` — no work to dequeue, code loads cleanly.
- [ ] Real-world: next time a `kitchen-run-now` worker dies mid-node, confirm the cron-tick worker picks up the reclaim within one tick instead of waiting out the full TTL.