### PR TITLE
fix: remove stale message received hook

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -243,7 +243,6 @@ const recipesPlugin = {
     };
 
     api.on("message_received" as never, approvalReplyHandler as never, { priority: 50 } as unknown as { priority: number });
-    api.on("message:received" as never, approvalReplyHandler as never, { priority: 50 } as unknown as { priority: number });
 
 
     // On plugin load, ensure multi-agent config has an explicit agents.list with main at top.


### PR DESCRIPTION
## Summary
- remove the unsupported `message:received` plugin hook registration
- keep the valid `message_received` registration for approval reply handling
- stop the noisy gateway startup warning on OpenClaw 2026.4.25

## Testing
- npm run lint -- index.ts
  - passes with pre-existing repo warnings only