### PR TITLE
fix(recipes-config): silence runtime-config-load-write deprecation

### DIFF
--- a/src/lib/recipes-config.ts
+++ b/src/lib/recipes-config.ts
@@ -2,34 +2,49 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { upsertAgentInConfig, type AgentConfigSnippet } from "./agent-config";
 import { stableStringify } from "./stable-stringify";
 
-/** Runtime API shape for config access (plugin SDK may not expose types). */
+/**
+ * Runtime API shape for config access. Mirrors the modern surface
+ * (`current` + `replaceConfigFile`) so we don't trigger the
+ * `runtime-config-load-write` deprecation warning that the legacy
+ * `loadConfig` / `writeConfigFile` helpers emit.
+ */
 interface OpenClawRuntimeConfig {
-  loadConfig?: () => { cfg?: unknown } | unknown;
-  writeConfigFile?: (cfg: unknown) => Promise<void>;
+  current?: () => unknown;
+  replaceConfigFile?: (params: {
+    nextConfig: unknown;
+    afterWrite: { mode: "auto" } | { mode: "restart"; reason: string } | { mode: "none"; reason: string };
+  }) => Promise<unknown>;
 }
 
 /**
  * Load OpenClaw config via runtime API.
+ * Returns a deep clone of the runtime snapshot so callers may mutate it
+ * before persisting via {@link writeOpenClawConfig}; the runtime's own
+ * snapshot from `current()` is `DeepReadonly` and must not be mutated.
  * @param api - OpenClaw plugin API
- * @returns Config object (mutable)
- * @throws If loadConfig fails
+ * @returns Config object (mutable copy)
+ * @throws If the runtime config API is unavailable
  */
 export async function loadOpenClawConfig(api: OpenClawPluginApi): Promise<Record<string, unknown>> {
   const runtime = api.runtime as { config?: OpenClawRuntimeConfig };
-  const current = runtime.config?.loadConfig?.();
-  if (!current) throw new Error("Failed to load config via api.runtime.config.loadConfig()");
-  const cfgObj = (current as { cfg?: unknown }).cfg ?? current;
-  return cfgObj as Record<string, unknown>;
+  const snapshot = runtime.config?.current?.();
+  if (!snapshot) throw new Error("Failed to load config via api.runtime.config.current()");
+  return JSON.parse(JSON.stringify(snapshot)) as Record<string, unknown>;
 }
 
 /**
- * Write OpenClaw config via runtime API.
+ * Persist a full OpenClaw config replacement via the runtime API.
+ * Uses `afterWrite: { mode: "auto" }` to let the gateway choose between
+ * hot-reload and restart, matching the legacy `writeConfigFile` default.
  * @param api - OpenClaw plugin API
  * @param cfgObj - Config object to write
  */
 export async function writeOpenClawConfig(api: OpenClawPluginApi, cfgObj: Record<string, unknown>): Promise<void> {
   const runtime = api.runtime as { config?: OpenClawRuntimeConfig };
-  await runtime.config?.writeConfigFile?.(cfgObj);
+  await runtime.config?.replaceConfigFile?.({
+    nextConfig: cfgObj,
+    afterWrite: { mode: "auto" },
+  });
 }
 
 export type BindingMatch = {

--- a/tests/cov-10.test.ts
+++ b/tests/cov-10.test.ts
@@ -54,9 +54,9 @@ describe("cov-10: reconcileRecipeCronJobs, promptYesNo, applyAgentSnippets", () 
         config: { agents: { defaults: { workspace: "/ws" } } },
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async (c: any) => {
-              Object.assign(cfgObj, c);
+            current: () => cfgObj,
+            replaceConfigFile: async ({ nextConfig }: { nextConfig: any }) => {
+              Object.assign(cfgObj, nextConfig);
             },
           },
         },
@@ -83,9 +83,9 @@ describe("cov-10: reconcileRecipeCronJobs, promptYesNo, applyAgentSnippets", () 
         config: { agents: { defaults: { workspace: "/ws" } } },
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async (c: unknown) => {
-              Object.assign(cfgObj, c);
+            current: () => cfgObj,
+            replaceConfigFile: async ({ nextConfig }: { nextConfig: unknown }) => {
+              Object.assign(cfgObj, nextConfig);
             },
           },
         },
@@ -106,9 +106,9 @@ describe("cov-10: reconcileRecipeCronJobs, promptYesNo, applyAgentSnippets", () 
         config: { agents: { defaults: { workspace: "/ws" } } },
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async (c: unknown) => {
-              Object.assign(cfgObj, c);
+            current: () => cfgObj,
+            replaceConfigFile: async ({ nextConfig }: { nextConfig: unknown }) => {
+              Object.assign(cfgObj, nextConfig);
             },
           },
         },

--- a/tests/index-handlers.test.ts
+++ b/tests/index-handlers.test.ts
@@ -97,8 +97,8 @@ describe("index.ts handlers (remove-team)", () => {
         config: { agents: { defaults: { workspace: workspaceRoot } } },
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async () => {},
+            current: () => cfgObj,
+            replaceConfigFile: async () => {},
           },
         },
       } as any;
@@ -120,7 +120,7 @@ describe("index.ts handlers (remove-team)", () => {
       const cfgObj = { agents: { list: [] } };
       const api = {
         config: { agents: { defaults: { workspace: workspaceRoot } } },
-        runtime: { config: { loadConfig: () => ({ cfg: cfgObj }), writeConfigFile: async () => {} } },
+        runtime: { config: { current: () => cfgObj, replaceConfigFile: async () => {} } },
       } as any;
       const origTTY = process.stdin.isTTY;
       Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
@@ -146,7 +146,7 @@ describe("index.ts handlers (remove-team)", () => {
       const cfgObj = { agents: { list: [] } };
       const api = {
         config: { agents: { defaults: { workspace: workspaceRoot } } },
-        runtime: { config: { loadConfig: () => ({ cfg: cfgObj }), writeConfigFile: async () => {} } },
+        runtime: { config: { current: () => cfgObj, replaceConfigFile: async () => {} } },
       } as any;
       const orig = process.stdin.isTTY;
       Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
@@ -173,9 +173,9 @@ describe("index.ts handlers (remove-team)", () => {
         config: { agents: { defaults: { workspace: workspaceRoot } } },
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async (c: any) => {
-              Object.assign(cfgObj, c);
+            current: () => cfgObj,
+            replaceConfigFile: async ({ nextConfig }: { nextConfig: any }) => {
+              Object.assign(cfgObj, nextConfig);
             },
           },
         },

--- a/tests/recipes-commands.test.ts
+++ b/tests/recipes-commands.test.ts
@@ -15,9 +15,9 @@ function mockApi(overrides: { workspace?: string; cfgObj?: any } = {}) {
     },
     runtime: {
       config: {
-        loadConfig: () => ({ cfg: cfgObj }),
-        writeConfigFile: async (c: any) => {
-          Object.assign(cfgObj, c);
+        current: () => cfgObj,
+        replaceConfigFile: async ({ nextConfig }: { nextConfig: any }) => {
+          Object.assign(cfgObj, nextConfig);
         },
       },
     },

--- a/tests/scaffold-commands.test.ts
+++ b/tests/scaffold-commands.test.ts
@@ -94,8 +94,8 @@ files: []
         ...mockApi(workspaceRoot),
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async (c: any) => Object.assign(cfgObj, c),
+            current: () => cfgObj,
+            replaceConfigFile: async ({ nextConfig }: { nextConfig: any }) => Object.assign(cfgObj, nextConfig),
           },
         },
       } as any;
@@ -546,8 +546,8 @@ describe("migrate-team integration", () => {
         config: { agents: { defaults: { workspace: workspaceRoot } } },
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async (c: any) => Object.assign(cfgObj, c),
+            current: () => cfgObj,
+            replaceConfigFile: async ({ nextConfig }: { nextConfig: any }) => Object.assign(cfgObj, nextConfig),
           },
         },
       } as any;
@@ -580,8 +580,8 @@ describe("migrate-team integration", () => {
         config: { agents: { defaults: { workspace: workspaceRoot } } },
         runtime: {
           config: {
-            loadConfig: () => ({ cfg: cfgObj }),
-            writeConfigFile: async (c: any) => Object.assign(cfgObj, c),
+            current: () => cfgObj,
+            replaceConfigFile: async ({ nextConfig }: { nextConfig: any }) => Object.assign(cfgObj, nextConfig),
           },
         },
       } as any;


### PR DESCRIPTION
## Summary

Replaces the deprecated `api.runtime.config.loadConfig()` / `writeConfigFile()` calls in `src/lib/recipes-config.ts` with the modern `current()` / `replaceConfigFile()` surface. This silences the `runtime-config-load-write` warning that the OpenClaw runtime emits on every plugin call into the legacy API.

## Why this matters (real-world symptom)

The deprecation prints to **stdout** from `logWarn`. Today the `openclaw recipes list` invocation from ClawKitchen produced a stdout that began with the deprecation banner. Under one execution path the JSON recipe array never followed, and the kitchen subprocess cache stored `{ ok: true, exitCode: 0, stdout: "<deprecation only>" }`. The team editor then `JSON.parse`'d the empty stdout, returned `[]` from `findRecipeById`, and threw **"Recipe not found: hmx-marketing-team"** for ~30 minutes until the cache TTL expired.

Removing the deprecation source removes the most likely cause of that stdout pollution. (The kitchen-side cache also deserves a guard against caching ok-with-no-JSON results — separate issue.)

## Changes

- `src/lib/recipes-config.ts`
  - `loadOpenClawConfig`: now reads `runtime.config.current()` and returns a JSON deep clone, since `current()` returns `DeepReadonly` and callers expect a mutable draft.
  - `writeOpenClawConfig`: now calls `runtime.config.replaceConfigFile({ nextConfig, afterWrite: { mode: "auto" } })` — `auto` matches the legacy `writeConfigFile` default behavior, letting the gateway pick hot-reload vs restart.
  - Public function signatures unchanged; all callers (`applyAgentSnippetsToOpenClawConfig`, `applyBindingSnippetsToOpenClawConfig`, `src/handlers/recipes.ts`, `src/handlers/team.ts`, `src/lib/workflows/workflow-node-executor.ts`) keep working as-is.
- `tests/{cov-10,index-handlers,recipes-commands,scaffold-commands}.test.ts`
  - Test mocks updated to expose `current` + `replaceConfigFile` instead of the legacy `loadConfig` + `writeConfigFile`.

## Test plan

- [x] `npm test` — 301 pass, 0 fail
- [x] `npm run check:plugin-version` — OK
- [x] `npm run smell-check` — passed (`as any` count unchanged at 3)
- [ ] Smoke test in a running gateway: scaffold a team, install an agent, verify no `runtime-config-load-write` deprecation in stdout/log

🤖 Generated with [Claude Code](https://claude.com/claude-code)