### PR TITLE
fix(workflow-approval): direct telegram bot fallback when message tool unavailable

### DIFF
--- a/src/lib/workflows/workflow-node-executor.ts
+++ b/src/lib/workflows/workflow-node-executor.ts
@@ -305,16 +305,59 @@ export async function executeWorkflowNodes(opts: {
         `- openclaw recipes workflows resume --team-id ${teamId} --run-id ${runId}`,
       ].join('\n');
 
-      await toolsInvoke<ToolTextResult>(api, {
-        tool: 'message',
-        args: {
-          action: 'send',
-          channel,
-          target,
-          ...(accountId ? { accountId } : {}),
-          message: msg,
-        },
-      });
+      // Deliver the approval prompt. Wrap in try/catch + Telegram bot-API
+      // fallback because OpenClaw 2026.4.26's gateway has been observed to
+      // return "Tool not available: message" from /tools/invoke even though
+      // the channel itself is healthy. The approval.json file is durable
+      // either way, so we never fail the run on delivery error — operators
+      // can still approve via the kitchen UI or `openclaw recipes workflows
+      // approve` CLI when this falls through.
+      let approvalDelivered = false;
+      try {
+        await toolsInvoke<ToolTextResult>(api, {
+          tool: 'message',
+          args: {
+            action: 'send',
+            channel,
+            target,
+            ...(accountId ? { accountId } : {}),
+            message: msg,
+          },
+        });
+        approvalDelivered = true;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.warn(`[workflow] tools.invoke('message') failed for run ${runId} on node ${node.id}: ${errMsg}`);
+        if (channel === 'telegram') {
+          try {
+            const cfg = await loadOpenClawConfig(api);
+            const tgToken = (cfg as { channels?: { telegram?: { botToken?: string } } })
+              .channels?.telegram?.botToken;
+            if (tgToken) {
+              const tgRes = await fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ chat_id: target, text: msg }),
+              });
+              if (tgRes.ok) {
+                approvalDelivered = true;
+                console.log(`[workflow] approval delivered via direct telegram bot API for run ${runId}`);
+              } else {
+                const tgBody = await tgRes.text().catch(() => '');
+                console.error(`[workflow] telegram fallback failed (${tgRes.status}) for run ${runId}: ${tgBody}`);
+              }
+            } else {
+              console.error(`[workflow] telegram fallback skipped for run ${runId}: missing channels.telegram.botToken in openclaw config`);
+            }
+          } catch (fbErr) {
+            const fbMsg = fbErr instanceof Error ? fbErr.message : String(fbErr);
+            console.error(`[workflow] telegram fallback threw for run ${runId}: ${fbMsg}`);
+          }
+        }
+        if (!approvalDelivered) {
+          console.warn(`[workflow] approval message not delivered for run ${runId}; approve via kitchen UI or CLI`);
+        }
+      }
 
       const waitingTs = new Date().toISOString();
       await appendRunLog(runLogPath, (cur) => ({


### PR DESCRIPTION
## Summary
OpenClaw 2026.4.26's gateway returns `Tool not available: message` from `/tools/invoke` even when the telegram channel is healthy (channel enabled, bot token present, agent chat replies still work). The workflow runtime's `human_approval` node uses `tools.invoke('message', { action: 'send', channel, target, ... })` to deliver approval prompts, so the failure causes Telegram approval notifications to disappear silently.

## Reproduction
```bash
curl -sS -X POST -H "authorization: Bearer <gateway-token>" \
  -H "content-type: application/json" \
  -d '{"tool":"message","args":{"action":"send","channel":"telegram","target":"<chat-id>","message":"hi"}}' \
  http://127.0.0.1:18789/tools/invoke
# {"ok":false,"error":{"type":"not_found","message":"Tool not available: message"}}
```

The same call succeeds in older OpenClaw builds. Telegram itself is fine — DM replies via the agent loop go through every day.

## Fix
- Wrap the `toolsInvoke('message', …)` call in `try/catch`.
- On any error, when `channel === 'telegram'`, fall back to a direct `https://api.telegram.org/bot<token>/sendMessage` POST using `channels.telegram.botToken` from the same OpenClaw config the binding resolver already loads.
- Never fail the run on delivery error — `approval.json` is durable, so operators can still approve via the kitchen UI or `openclaw recipes workflows approve` CLI when delivery falls through entirely.
- Verbose `console.warn`/`console.error`/`console.log` on every branch so future debugging is immediate.

This is a defensive workaround. Filing the upstream OpenClaw bug for the missing `message` tool in parallel.

## Test plan
- [x] `vitest run` — 47 files / 301 tests pass
- [ ] Trigger a `human_approval` node end-to-end on a workspace with a known-good telegram binding; confirm message arrives via direct bot API and the approval flow still completes via UI/CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)